### PR TITLE
[feat] AWS S3 연동 및 사용자 프로필 사진 업로드, 매물 사진 리스트 업로드 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -52,6 +52,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/woochacha/backend/config/S3Config.java
+++ b/backend/src/main/java/com/woochacha/backend/config/S3Config.java
@@ -1,0 +1,28 @@
+package com.woochacha.backend.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials= new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/backend/src/main/java/com/woochacha/backend/config/S3Config.java
+++ b/backend/src/main/java/com/woochacha/backend/config/S3Config.java
@@ -17,6 +17,7 @@ public class S3Config {
     @Value("${cloud.aws.region.static}")
     private String region;
 
+
     @Bean
     public AmazonS3Client amazonS3Client() {
         BasicAWSCredentials awsCredentials= new BasicAWSCredentials(accessKey, secretKey);

--- a/backend/src/main/java/com/woochacha/backend/config/WebConfig.java
+++ b/backend/src/main/java/com/woochacha/backend/config/WebConfig.java
@@ -8,7 +8,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:8080", "http://localhost:3000","http://localhost:5500",
-                        "http://127.0.0.1:8080", "http://127.0.0.1:5500") // 허용할 출처
+                        "http://127.0.0.1:8080", "http://127.0.0.1:5500", "https://web.postman.co/") // 허용할 출처
                 .allowedMethods("GET", "POST", "PATCH") // 허용할 HTTP method
                 .allowCredentials(true) // 쿠키 인증 요청 허용
                 .maxAge(3000);

--- a/backend/src/main/java/com/woochacha/backend/domain/AmazonS3/controller/AmazonS3Controller.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/AmazonS3/controller/AmazonS3Controller.java
@@ -1,0 +1,35 @@
+package com.woochacha.backend.domain.AmazonS3.controller;
+
+import com.woochacha.backend.domain.AmazonS3.dto.AmazonS3ProductRequestDto;
+import com.woochacha.backend.domain.AmazonS3.dto.AmazonS3RequestDto;
+import com.woochacha.backend.domain.AmazonS3.service.AmazonS3Service;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.*;
+
+import javax.transaction.Transactional;
+import java.io.IOException;
+
+//@Transactional // JPA에서 update/delete 쿼리를 사용하기 위해 처리해줘야 함
+@RestController
+@RequestMapping("/s3")
+public class AmazonS3Controller {
+
+    public final AmazonS3Service amazonS3Service;
+
+    public AmazonS3Controller(AmazonS3Service amazonS3Service) {
+        this.amazonS3Service = amazonS3Service;
+    }
+
+    @Transactional
+    @PostMapping("/upload-profile")
+    public String uploadProfile(@ModelAttribute AmazonS3RequestDto amazonS3RequestDto) throws IOException {
+        return amazonS3Service.uploadProfile(amazonS3RequestDto);
+    }
+
+    @PostMapping("/upload-product")
+    public boolean uploadProfile(@ModelAttribute AmazonS3ProductRequestDto amazonS3ProductRequestDto) throws IOException {
+        return amazonS3Service.uploadProductImage(amazonS3ProductRequestDto);
+    }
+
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/AmazonS3/dto/AmazonS3ProductRequestDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/AmazonS3/dto/AmazonS3ProductRequestDto.java
@@ -1,0 +1,12 @@
+package com.woochacha.backend.domain.AmazonS3.dto;
+
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Data
+public class AmazonS3ProductRequestDto {
+    List<MultipartFile> multipartFileList;
+    String carNum;
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/AmazonS3/dto/AmazonS3RequestDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/AmazonS3/dto/AmazonS3RequestDto.java
@@ -1,0 +1,10 @@
+package com.woochacha.backend.domain.AmazonS3.dto;
+
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+public class AmazonS3RequestDto {
+    MultipartFile multipartFile;
+    String email;
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/AmazonS3/service/AmazonS3Service.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/AmazonS3/service/AmazonS3Service.java
@@ -1,0 +1,14 @@
+package com.woochacha.backend.domain.AmazonS3.service;
+
+import com.woochacha.backend.domain.AmazonS3.dto.AmazonS3ProductRequestDto;
+import com.woochacha.backend.domain.AmazonS3.dto.AmazonS3RequestDto;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+public interface AmazonS3Service {
+    public String uploadProfile(AmazonS3RequestDto amazonS3RequestDto) throws IOException;
+
+    public boolean uploadProductImage(AmazonS3ProductRequestDto amazonS3ProductRequestDto) throws IOException;
+    public String removeFile(Long id) throws IOException;
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/AmazonS3/service/AmazonS3ServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/AmazonS3/service/AmazonS3ServiceImpl.java
@@ -1,0 +1,145 @@
+package com.woochacha.backend.domain.AmazonS3.service;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.woochacha.backend.domain.AmazonS3.dto.AmazonS3ProductRequestDto;
+import com.woochacha.backend.domain.AmazonS3.dto.AmazonS3RequestDto;
+import com.woochacha.backend.domain.car.detail.entity.QCarDetail;
+import com.woochacha.backend.domain.member.entity.QMember;
+import com.woochacha.backend.domain.product.entity.QCarImage;
+import com.woochacha.backend.domain.product.entity.QProduct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.transaction.Transactional;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+@Service
+public class AmazonS3ServiceImpl implements AmazonS3Service {
+
+    private final Logger LOGGER = LoggerFactory.getLogger(AmazonS3ServiceImpl.class);
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+
+    private final JPAQueryFactory queryFactory;
+
+    public AmazonS3ServiceImpl(JPAQueryFactory queryFactory, AmazonS3 amazonS3) {
+        this.amazonS3 = amazonS3;
+        this.queryFactory = queryFactory;
+    }
+
+
+    public String upload(String folderName, String fileName, MultipartFile multipartFile) throws IOException {
+        InputStream file = multipartFile.getInputStream();
+
+        try {
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setCacheControl("no-cached, no-store, must-revalidate"); // 60*60*24*7 일주일
+            metadata.setContentType("image/png");
+            PutObjectRequest request = new PutObjectRequest(bucket + folderName, fileName, file, metadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead);
+            amazonS3.putObject(request);
+
+            String url = "s3://" + bucket + folderName + "/" + fileName;
+
+            return url;
+
+        } catch (AmazonClientException e) {
+            e.printStackTrace();
+            return "false";
+        }
+    }
+
+    public ResponseEntity<Boolean> saveProfileImage(String email, String url) {
+        try {
+            long clause = queryFactory
+                    .update(QMember.member)
+                    .set(QMember.member.profileImage, url)
+                    .where(QMember.member.email.eq(email))
+                    .execute();
+            return ResponseEntity.ok(true);
+        } catch (Exception e) {
+            return ResponseEntity.ok(false);
+        }
+    }
+
+
+//    public void saveProductImage(@Param("productId") Long productId, @Param("url") String url) {
+    @Modifying
+    @Query(value = "insert into car_image (product_id, image_url) values (:productId, :url)", nativeQuery = true)
+    public void saveProductImage(Long productId, String url) {
+        try {
+//            queryFactory
+//                    .insert(QCarImage.carImage)
+//                    .columns(QCarImage.carImage.product.id, QCarImage.carImage.imageUrl)
+//                    .values(productId, url)
+//                    .execute();
+
+//            return ResponseEntity.ok(true);
+        } catch (Exception e) {
+//            return ResponseEntity.ok(false);
+        }
+
+
+    }
+
+    public String uploadProfile(AmazonS3RequestDto amazonS3RequestDto) throws IOException {
+        String url = this.upload("/profile", amazonS3RequestDto.getEmail(), amazonS3RequestDto.getMultipartFile());
+        this.saveProfileImage(amazonS3RequestDto.getEmail(), url);
+        return url;
+    }
+
+    public boolean uploadProductImage(AmazonS3ProductRequestDto amazonS3ProductRequestDto) throws IOException {
+        List<MultipartFile> multipartFileList = amazonS3ProductRequestDto.getMultipartFileList();
+        int count = 0;
+
+        String carNum = amazonS3ProductRequestDto.getCarNum();
+
+        Long productId = null;
+
+        try {
+            productId = queryFactory
+                    .select(QProduct.product.id)
+                    .from(QProduct.product)
+                    .join(QCarDetail.carDetail)
+                    .on(QProduct.product.carDetail.carNum.eq(QCarDetail.carDetail.carNum))
+                    .where(QCarDetail.carDetail.carNum.eq(carNum))
+                    .fetchOne();
+
+            LOGGER.info("[product id] " + productId);
+
+            if (productId == null) {
+                throw new Exception("찾는 차량 번호가 없습니다.");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        for (MultipartFile multipartFile : multipartFileList) {
+            String url = this.upload("/product/" + carNum, String.valueOf(++count), multipartFile);
+            this.saveProductImage(productId, url);
+        }
+        return true;
+    }
+
+    @Override
+    public String removeFile(Long id) throws IOException {
+        return null;
+    }
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/member/service/impl/SignServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/service/impl/SignServiceImpl.java
@@ -17,6 +17,8 @@ import com.woochacha.backend.domain.member.repository.MemberRepository;
 import com.woochacha.backend.domain.member.service.SignService;
 import com.woochacha.backend.domain.product.entity.QCarImage;
 import org.modelmapper.ModelMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;

--- a/backend/src/main/java/com/woochacha/backend/domain/product/entity/CarImage.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/entity/CarImage.java
@@ -1,6 +1,6 @@
 package com.woochacha.backend.domain.product.entity;
 
-import lombok.Getter;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicInsert;
 
@@ -11,6 +11,8 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @DynamicInsert
+@Builder
+@AllArgsConstructor
 @Table(name = "car_image")
 // 차량 이미지 URL 데이터 저장 엔티티
 public class CarImage {
@@ -25,6 +27,10 @@ public class CarImage {
     private String imageUrl;
 
     @CreationTimestamp
-    @NotBlank
+//    @NotBlank
     private LocalDateTime createdAt;
+
+    public CarImage() {
+
+    }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/product/entity/Product.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/entity/Product.java
@@ -4,6 +4,7 @@ import com.woochacha.backend.domain.car.detail.entity.CarDetail;
 import com.woochacha.backend.domain.sale.entity.SaleForm;
 import com.woochacha.backend.domain.status.entity.CarStatus;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
@@ -32,11 +33,11 @@ public class Product {
     private Integer price;
 
     @CreationTimestamp
-    @NotBlank
+//    @NotBlank
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
-    @NotBlank
+//    @NotBlank
     private LocalDateTime updatedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/woochacha/backend/domain/product/entity/Product.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/entity/Product.java
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @DynamicInsert
-@Table(name = "table")
+@Table(name = "product")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 // 게시글 정보 관리 엔티티
 public class Product {
@@ -45,5 +45,6 @@ public class Product {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "car_num")
+//    @JoinColumn(referencedColumnName = "car_num")
     private CarDetail carDetail;
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/product/repository/CarImageRepository.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/repository/CarImageRepository.java
@@ -1,0 +1,10 @@
+package com.woochacha.backend.domain.product.repository;
+
+import com.woochacha.backend.domain.product.entity.CarImage;
+import com.woochacha.backend.domain.product.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CarImageRepository extends JpaRepository<CarImage, Long> {
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/product/repository/ProductRepository.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/repository/ProductRepository.java
@@ -1,0 +1,9 @@
+package com.woochacha.backend.domain.product.repository;
+
+import com.woochacha.backend.domain.product.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/backend/src/main/java/com/woochacha/backend/security/configs/SecurityConfig.java
+++ b/backend/src/main/java/com/woochacha/backend/security/configs/SecurityConfig.java
@@ -81,10 +81,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
 
                 .authorizeRequests()
-                .antMatchers("/", "/users/register", "/users/login").permitAll()
-                .antMatchers("/products", "/products/details/**", "/products/filter", "/products/search").permitAll()
-                .antMatchers("/users/**", "/products/**").hasRole("USER")
-                .antMatchers("/admin").hasRole("ADMIN")
+                .antMatchers("/**").permitAll()
+//                .antMatchers("/", "/users/register", "/users/login").permitAll()
+//                .antMatchers("/products", "/products/details/**", "/products/filter", "/products/search").permitAll()
+//                .antMatchers("/users/**", "/products/**").hasRole("USER")
+//                .antMatchers("/admin").hasRole("ADMIN")
 
                 .anyRequest().authenticated()
 


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- AWS S3 연동
- 사용자 프로필 사진 업로드 및 DB 저장 기능 구현
- 매물 사진 리스트 업로드 및 DB 저장 기능 구현
- 모든 페이지에 권한 인증 제거

## 관련 이슈

- Close #35

## 세부 작업 내용

- [x] AmazonS3 도메인 생성 및 MVC 패턴 적용
- [x] 사용자, 매물 각각 RequestDto 생성
- [x] 사용자 프로필의 경우 계정의 이메일로 사진 업로드
- [x] 매물의 경우 "차량번호" 폴더에 1부터 1씩 증가하며 사진 업로드
- [x] DB의 member 테이블에 이미지 uri 저장
- [x] DB의 car_image 테이블에 이미지 uri 저장

## 참고 사항
[사용자 프로필 사진]
- 프론트로부터 받아올 객체 정보는 {사진 한 장, 이메일}입니다.
![image](https://github.com/woorifisa-projects/woochacha/assets/93786956/c05df713-ceea-4654-b5e1-e7401f0e1067)
- S3에 저장되는 경로는 "/profile/{member.email}" 입니다.
<br>

[관리자 매물 사진 리스트]
- 프론트로부터 받아올 객체 정보는 {사진 여러 장, 차량 번호}입니다.
![image](https://github.com/woorifisa-projects/woochacha/assets/93786956/7d512248-b5fc-46f0-93ef-626e94746b21)
- S3에 저장되는 경로는 "/product/{product.car_num}/{count}.jpg"입니다. 여기서 count는 1부터 차례대로 증가합니다.

- 매물 사진 리스트의 경우 우선 JPQL로 작성하였으며 추후 QueryDSL로 리팩토링 예정입니다.