### PR TITLE
[feat] 로그인 기능 구현

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -14,6 +14,7 @@
   // 필요없는 규칙은 off해서 꺼주세요
   "rules": {
     "react/react-in-jsx-scope": "off",
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "react/display-name": "off" // HOC 관련 eslint 추가
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -635,6 +635,20 @@
         "tslib": "^2.4.0"
       }
     },
+    "@types/cookie": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.1.tgz",
+      "integrity": "sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g=="
+    },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -1125,6 +1139,11 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -2806,6 +2825,16 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "react-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-6.0.1.tgz",
+      "integrity": "sha512-17Xi49dmBwuj+clFjTv9O/10zhiVWB8UvA6GxOSuwmrqr1MQ5MsiYNZnSDbYl2vKDPIfuHWIDA4ntT723Pfpgg==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "hoist-non-react-statics": "^3.3.2",
+        "universal-cookie": "^6.0.0"
+      }
+    },
     "react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -2882,6 +2911,11 @@
       "requires": {
         "hamt_plus": "1.0.2"
       }
+    },
+    "recoil-persist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-5.1.0.tgz",
+      "integrity": "sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w=="
     },
     "regenerator-runtime": {
       "version": "0.14.0",
@@ -3333,6 +3367,15 @@
         "has-bigints": "^1.0.2",
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
+      }
+    },
+    "universal-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-6.0.1.tgz",
+      "integrity": "sha512-azv2SDvVjl1jyAsHEWaBAWlxIV0HTAJj3VDlak76C2JPAojlJEXdZiU+9w6D6fOydLyFGxvUWmT1m3f1mdLnEQ==",
+      "requires": {
+        "@types/cookie": "^0.5.1",
+        "cookie": "^0.5.0"
       }
     },
     "unload": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,9 +20,11 @@
     "next": "13.4.13",
     "postcss": "8.4.27",
     "react": "18.2.0",
+    "react-cookie": "^6.0.1",
     "react-dom": "18.2.0",
     "react-query": "^3.39.3",
     "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0",
     "tailwindcss": "3.3.3"
   },
   "devDependencies": {

--- a/frontend/src/atoms/userInfoAtoms.js
+++ b/frontend/src/atoms/userInfoAtoms.js
@@ -1,0 +1,21 @@
+const { atom } = require('recoil');
+import { recoilPersist } from 'recoil-persist';
+
+// TODO: login 한 유저의 정보를 받아오기
+const userInfoState = atom({
+  key: 'userInfoState',
+  default: {},
+});
+
+const { persistAtom } = recoilPersist({
+  key: 'recoil-persist',
+  storage: typeof window === 'undefined' ? undefined : sessionStorage,
+});
+
+const userLoggedInState = atom({
+  key: 'userLoggedInState',
+  default: false,
+  // effects_UNSTABLE: [persistAtom],
+});
+
+export { userInfoState, userLoggedInState };

--- a/frontend/src/components/auth/LoginForm.js
+++ b/frontend/src/components/auth/LoginForm.js
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react';
 import { checkLoginValidate, handleSignupBlur } from '@/hooks/useChecks';
 import { loginApi } from '@/services/authApi';
+import { useRecoilState } from 'recoil';
+import { userInfoState, userLoggedInState } from '@/atoms/userInfoAtoms';
+import { useRouter } from 'next/router';
 
 import {
   Button,
@@ -19,6 +22,10 @@ import {
 import theme from '@/styles/theme';
 
 export default function LoginForm() {
+  const [loginToken, setLoginToken] = useRecoilState(userLoggedInState);
+  const [userInfo, setUserInfo] = useRecoilState(userInfoState);
+  const router = useRouter();
+
   const [clickSubmit, setClickSubmit] = useState(true);
   const [loginData, setLoginData] = useState({
     email: '',
@@ -47,7 +54,7 @@ export default function LoginForm() {
   // TODO: 데이터 넘기기
   useEffect(() => {
     if (!Object.values(formValid).includes(true) && !Object.values(loginData).includes('')) {
-      loginApi(loginData);
+      loginApi(loginData, setLoginToken, setUserInfo, router);
     }
   }, [clickSubmit]);
 

--- a/frontend/src/components/auth/SignupForm.js
+++ b/frontend/src/components/auth/SignupForm.js
@@ -1,5 +1,8 @@
 import { useEffect, useState } from 'react';
 import { checkFormValidate, handleSignupBlur } from '@/hooks/useChecks';
+import { useRecoilState } from 'recoil';
+import { useRouter } from 'next/router';
+import { userInfoState, userLoggedInState } from '@/atoms/userInfoAtoms';
 import { signupApi } from '@/services/authApi';
 
 import {
@@ -19,6 +22,10 @@ import {
 import theme from '@/styles/theme';
 
 export default function SignupForm() {
+  const [loginToken, setLoginToken] = useRecoilState(userLoggedInState);
+  const [userInfo, setUserInfo] = useRecoilState(userInfoState);
+  const router = useRouter();
+
   const [clickSubmit, setClickSubmit] = useState(true);
   const [signupData, setSignupData] = useState({
     email: '',
@@ -56,7 +63,8 @@ export default function SignupForm() {
   // TODO: 데이터 넘기기
   useEffect(() => {
     if (!Object.values(formValid).includes(true) && !Object.values(signupData).includes('')) {
-      signupApi(signupData);
+      console.log(signupData);
+      signupApi(signupData, setLoginToken, setUserInfo, router);
     }
   }, [clickSubmit]);
 

--- a/frontend/src/components/common/ProfileAppbar.js
+++ b/frontend/src/components/common/ProfileAppbar.js
@@ -1,9 +1,13 @@
 import React from 'react';
 import { useRouter } from 'next/router';
+import { useRecoilState } from 'recoil';
+import { userLoggedInState } from '@/atoms/userInfoAtoms';
 import { Avatar, IconButton, Menu, MenuItem, Tooltip, Typography } from '@mui/material';
-import { HEADER_USER_MENU } from '@/constants/string';
+import { HEADER_LOGIN_USER_MENU, HEADER_UNLOGIN_USER_MENU } from '@/constants/string';
+import LocalStorage from '@/utils/localStorage';
 
 export default function ProfileAppbar() {
+  const [userLoggedIn, setUserLoggedIn] = useRecoilState(userLoggedInState);
   const router = useRouter();
   const [anchorElUser, setAnchorElUser] = React.useState(null);
 
@@ -11,18 +15,41 @@ export default function ProfileAppbar() {
     setAnchorElUser(event.currentTarget);
   };
 
-  const handleCloseUserMenu = (url) => {
+  const handleCloseUserMenu = () => {
+    setAnchorElUser(null);
+  };
+
+  const handleCloseMiniMenu = (url) => {
+    if (url.includes('logout')) {
+      LocalStorage.removeItem('loginToken');
+      setUserLoggedIn(false);
+
+      // TODO: 로그아웃 modal 처리
+      alert('로그아웃 완료!');
+
+      router.push('/');
+      return;
+    }
     router.push(url);
     setAnchorElUser(null);
   };
 
   return (
     <>
-      <Tooltip title="Open settings">
-        <IconButton onClick={handleOpenUserMenu} sx={{ p: 0 }}>
-          <Avatar alt="Remy Sharp" src="/static/images/avatar/2.jpg" />
-        </IconButton>
-      </Tooltip>
+      {userLoggedIn ? (
+        <Tooltip title="홍길동님">
+          <IconButton onClick={handleOpenUserMenu} sx={{ p: 0 }}>
+            <Avatar alt="Remy Sharp" src="/static/images/avatar/2.jpg" />
+          </IconButton>
+        </Tooltip>
+      ) : (
+        <Tooltip title="로그인하기">
+          <IconButton onClick={handleOpenUserMenu} sx={{ p: 0 }}>
+            <Avatar alt="Remy Sharp" src="/static/images/avatar/2.jpg" />
+          </IconButton>
+        </Tooltip>
+      )}
+
       <Menu
         sx={{ mt: '45px' }}
         id="menu-appbar"
@@ -38,11 +65,21 @@ export default function ProfileAppbar() {
         }}
         open={Boolean(anchorElUser)}
         onClose={handleCloseUserMenu}>
-        {HEADER_USER_MENU.CONTENTS.map((userMenu) => (
-          <MenuItem key={userMenu.pageName} onClick={() => handleCloseUserMenu(userMenu.pageUrl)}>
-            <Typography textAlign="center">{userMenu.pageName}</Typography>
-          </MenuItem>
-        ))}
+        {userLoggedIn
+          ? HEADER_LOGIN_USER_MENU.CONTENTS.map((userMenu) => (
+              <MenuItem
+                key={userMenu.pageName}
+                onClick={() => handleCloseMiniMenu(userMenu.pageUrl)}>
+                <Typography textAlign="center">{userMenu.pageName}</Typography>
+              </MenuItem>
+            ))
+          : HEADER_UNLOGIN_USER_MENU.CONTENTS.map((userMenu) => (
+              <MenuItem
+                key={userMenu.pageName}
+                onClick={() => handleCloseMiniMenu(userMenu.pageUrl)}>
+                <Typography textAlign="center">{userMenu.pageName}</Typography>
+              </MenuItem>
+            ))}
       </Menu>
     </>
   );

--- a/frontend/src/constants/String.js
+++ b/frontend/src/constants/String.js
@@ -37,7 +37,7 @@ export const HEADER_MINI_MENU = {
   ],
 };
 
-export const HEADER_USER_MENU = {
+export const HEADER_UNLOGIN_USER_MENU = {
   CONTENTS: [
     {
       pageName: '로그인',
@@ -46,6 +46,19 @@ export const HEADER_USER_MENU = {
     {
       pageName: '회원가입',
       pageUrl: `/users/signup`,
+    },
+  ],
+};
+
+export const HEADER_LOGIN_USER_MENU = {
+  CONTENTS: [
+    {
+      pageName: '마이페이지',
+      pageUrl: `/mypage`,
+    },
+    {
+      pageName: '로그아웃',
+      pageUrl: `/users/logout`,
     },
     {
       pageName: '탈퇴하기',

--- a/frontend/src/hooks/withAuth.js
+++ b/frontend/src/hooks/withAuth.js
@@ -1,0 +1,32 @@
+import { useRouter } from 'next/router';
+import { useRecoilValue } from 'recoil';
+import { userLoggedInState } from '@/atoms/userInfoAtoms';
+
+const withAuth = (WrappedComponent) => {
+  return (props) => {
+    // 클라이언트(브라우저) 또는 서버에 있는지 확인
+    if (typeof window !== 'undefined') {
+      const Router = useRouter();
+      const userLoggedIn = useRecoilValue(userLoggedInState);
+
+      const loginToken = localStorage.getItem('loginToken');
+
+      // 토큰 없는 경우, 로그인 페이지로 이동
+      if (!loginToken || !userLoggedIn) {
+        Router.replace('/users/login');
+        return null;
+      }
+
+      // TODO: 토큰은 있는데, 검증이 안된 경우, 로컬 스토리지 삭제 후, 로그인 페이지로 이동
+      // authInstance
+
+      // 토큰 O 경우
+      return <WrappedComponent {...props} />;
+    }
+
+    // 서버에 있는 경우 null
+    return null;
+  };
+};
+
+export default withAuth;

--- a/frontend/src/layouts/DefaultHeader.js
+++ b/frontend/src/layouts/DefaultHeader.js
@@ -16,7 +16,11 @@ import { HEADER_MENU } from '@/constants/string';
 import MenuAppbar from '@/components/common/MenuAppbar';
 import ProfileAppbar from '@/components/common/ProfileAppbar';
 
+import { useRecoilValue } from 'recoil';
+import { userLoggedInState } from '@/atoms/userInfoAtoms';
+
 function DefaultHeader() {
+  const userLoggedIn = useRecoilValue(userLoggedInState);
   const router = useRouter();
 
   const [anchorElNav, setAnchorElNav] = React.useState(null);
@@ -85,7 +89,7 @@ function DefaultHeader() {
               ))}
 
               {/* mini-menu app bar compo */}
-              <MenuAppbar size="0" />
+              {userLoggedIn ? <MenuAppbar size="0" /> : ''}
             </Menu>
           </Box>
           <Typography
@@ -115,7 +119,7 @@ function DefaultHeader() {
               </MenuItem>
             ))}
             {/* mini-menu app bar compo */}
-            <MenuAppbar size="2" />
+            {userLoggedIn ? <MenuAppbar size="2" /> : ''}
           </Box>
 
           <Box sx={{ flexGrow: 0 }}>

--- a/frontend/src/pages/mypage/index.js
+++ b/frontend/src/pages/mypage/index.js
@@ -1,5 +1,8 @@
+import withAuth from '@/hooks/withAuth';
 import React from 'react';
 
-export default function Mypage() {
+function Mypage() {
   return <div>마이페이지</div>;
 }
+
+export default withAuth(Mypage);

--- a/frontend/src/services/authApi.js
+++ b/frontend/src/services/authApi.js
@@ -1,25 +1,35 @@
+// utils/authApi.js
+import LocalStorage from '@/utils/localStorage';
 import { jsonInstance } from '@/utils/api';
 
-export const signupApi = async (signupData) => {
-  console.log(signupData);
-  jsonInstance
-    .post('/users/register', JSON.stringify(signupData))
-    .then((res) => {
-      console.log('성공 : ', res.data);
-    })
-    .catch((err) => {
-      console.log('실패 : ', err);
-    });
+export const signupApi = async (signupData, setLoginToken, setUserInfo, router) => {
+  try {
+    const response = await jsonInstance.post('/users/register', JSON.stringify(signupData));
+
+    const loginToken = response.headers['authorization'];
+    LocalStorage.setItem('loginToken', loginToken);
+    setLoginToken(loginToken);
+    setUserInfo(response.data);
+    console.log('로그인 성공');
+    router.push('/');
+  } catch (error) {
+    console.log('실패 : ', error);
+    throw error;
+  }
 };
 
-export const loginApi = async (loginData) => {
-  console.log(loginData);
-  jsonInstance
-    .post('/users/login', JSON.stringify(loginData))
-    .then((res) => {
-      console.log('성공 : ', res.data);
-    })
-    .catch((err) => {
-      console.log('실패 : ', err);
-    });
+export const loginApi = async (loginData, setLoginToken, setUserInfo, router) => {
+  try {
+    const response = await jsonInstance.post('/users/login', JSON.stringify(loginData));
+
+    const loginToken = response.headers['authorization'];
+    LocalStorage.setItem('loginToken', loginToken);
+    setLoginToken(loginToken);
+    setUserInfo(response.data);
+    console.log('로그인 성공');
+    router.push('/');
+  } catch (error) {
+    console.log('실패 : ', error);
+    throw error;
+  }
 };

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import LocalStorage from './localStorage';
 
 const BASE_URL = 'http://localhost:8080';
 const HEADER_JSON = {
@@ -20,10 +21,10 @@ const axiosApi = (url, options) => {
 
 // 인증 필요 O 경우
 const axiosAuthApi = (url, options) => {
-  // const token = '토큰 값';
+  const token = LocalStorage.getItem('loginToken');
   const instance = axios.create({
     baseURL: url,
-    // headers: { Authorization: 'Bearer ' + token },
+    headers: { Authorization: 'Bearer ' + token },
     ...options,
   });
   return instance;

--- a/frontend/src/utils/localStorage.js
+++ b/frontend/src/utils/localStorage.js
@@ -1,0 +1,25 @@
+class LocalStorage {
+  constructor() {}
+
+  static setItem(key, value) {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(key, value);
+    }
+  }
+
+  static getItem(key) {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem(key);
+    }
+    // window객체 localStorage, sessionStorage는 값이 없을때 null
+    return null;
+  }
+
+  static removeItem(key) {
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem(key);
+    }
+  }
+}
+
+export default LocalStorage;


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- 로그인 기능 구현 및 로그인한 유저 정보 유지 기능 구현

## 관련 이슈

- Close #31 

## 세부 작업 내용

- [x]  로그인 api 요청 후 로컬스토리지 저장
- [x] 로그인 상태관리
- [x] 로그인 유저 정보 저장

## 참고 사항

- 아직 백엔드와 통신을 하지 않은 상태입니다.
EC2에 서버 테스트 후 수정사항이 있다면 새로운 이슈를 통해 수정할 예정입니다.
