### PR TITLE
[feat] 백엔드 마이페이지 판매이력 조회

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/controller/MypageController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/controller/MypageController.java
@@ -17,14 +17,28 @@ public class MypageController {
     }
 
     /*
-     [마이페이지 - 등록한 매물 조회]
-     반환 데이터 : "carName", "imageUrl", "price", "year", "distance", "branchId", "createdAt"
-     */
+    [마이페이지 - 등록한 매물 조회]
+    반환 데이터 : "carName", "imageUrl", "price", "year", "distance", "branch", "createdAt"
+    페이지네이션 : 한 페이지당 5개, 게시글 작성일 최신순으로 정렬
+    */
     @GetMapping("/registered/{user_id}")
     public ResponseEntity<Page<ProductResponseDto>> registeredProduct(@PathVariable Long user_id,
                                                                       @RequestParam(defaultValue = "0") int page,
                                                                       @RequestParam(defaultValue = "5") int size) {
         Page<ProductResponseDto> productsPage = mypageService.getRegisteredProductsByUserId(user_id, page, size);
+        return ResponseEntity.ok(productsPage);
+    }
+
+    /*
+     [마이페이지 - 판매 이력 조회]
+     반환 데이터 : "carName", "imageUrl", "price", "year", "distance", "branch", "createdAt"
+     페이지네이션 : 한 페이지당 5개, 게시글 작성일 최신순으로 정렬
+     */
+    @GetMapping("/sale/{user_id}")
+    public ResponseEntity<Page<ProductResponseDto>> soldProduct(@PathVariable Long user_id,
+                                                                @RequestParam(defaultValue = "0") int page,
+                                                                @RequestParam(defaultValue = "5") int size){
+        Page<ProductResponseDto> productsPage = mypageService.getSoldProductsByMemberId(user_id, page, size);
         return ResponseEntity.ok(productsPage);
     }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/repository/MypageRepository.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/repository/MypageRepository.java
@@ -12,19 +12,34 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MypageRepository extends JpaRepository<SaleForm, Long> {
 
-    // 마이페이지 - 등록한 매물 조회 (product.id가 같은 행은 하나만(첫 번째 행) 출력)
-    @Query("SELECT cd.carName, ci.imageUrl, p.price, cd.year, cd.distance, sf.branch, p.createdAt " +
+    // 마이페이지 - 등록한 매물 조회
+    @Query("SELECT cd.carName, ci.imageUrl, p.price, cd.year, cd.distance, sf.branch, p.createdAt "  +
             "FROM CarImage ci " +
             "JOIN ci.product p " +
             "JOIN p.carDetail cd " +
             "JOIN p.saleForm sf " +
-            "JOIN sf.member m " +
+            "JOIN sf.member m "  +
             "WHERE m.id = :userId AND p.status.id = 4 " +
-            "AND NOT EXISTS (" +
+            "AND NOT EXISTS(" +
             "SELECT 1 FROM Product p2 " +
-            "WHERE p2.id = p.id AND p2.createdAt < p.createdAt)" +
+            "WHERE p2.id = p.id AND p2.createdAt < p.createdAt) " +
             "GROUP BY cd.carName, cd.year, cd.distance, sf.branch.id, p.createdAt, p.id")
     Page<Object[]> getRegisteredProductsByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    // TODO: createAt을 게시글 등록일이 아닌 판매일로 수정 (transaction 테이블) -> 양방향 매핑으로 수정
+    // 마이페이지 - 판매 이력 조회 (product.id가 같은 행은 하나만(첫 번째 행) 출력)
+    @Query("SELECT cd.carName, ci.imageUrl, p.price, cd.year, cd.distance, sf.branch, p.createdAt "  +
+            "FROM CarImage ci " +
+            "JOIN ci.product p " +
+            "JOIN p.carDetail cd " +
+            "JOIN p.saleForm sf " +
+            "JOIN sf.member m "  +
+            "WHERE m.id = :userId AND p.status.id = 5 " +
+            "AND NOT EXISTS(" +
+            "SELECT 1 FROM Product p2 " +
+            "WHERE p2.id = p.id AND p2.createdAt < p.createdAt) " +
+            "GROUP BY cd.carName, cd.year, cd.distance, sf.branch.id, p.createdAt, p.id")
+    Page<Object[]> getSoldProductsByMemberId(@Param("userId") Long userId, Pageable pageable);
 }
 
 

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
@@ -22,15 +22,6 @@ public class MypageServiceImpl implements MypageService {
         this.mypageRepository = mypageRepository;
     }
 
-    // 페이지네이션 : 한 페이지당 5개, 게시글 작성일 최신순으로 정렬
-    @Transactional
-    public Page<ProductResponseDto> getRegisteredProductsByUserId(Long userId, int pageNumber, int pageSize) {
-        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("createdAt").descending());
-        Page<Object[]> productsPage = mypageRepository.getRegisteredProductsByUserId(userId, pageable);
-
-        return productsPage.map(this::arrayToProductResponseDto);
-    }
-
     // JPQL로 조회한 결과 ProductResponseDto로 변환해서 전달
     private ProductResponseDto arrayToProductResponseDto(Object[] array) {
         CarName carName = (CarName) array[0];
@@ -43,6 +34,24 @@ public class MypageServiceImpl implements MypageService {
                 (Branch) array[5],
                 (LocalDateTime) array[6]
         );
+    }
+
+    // 등록한 매물 조회 (최신 등록 순)
+    @Transactional
+    public Page<ProductResponseDto> getRegisteredProductsByUserId(Long userId, int pageNumber, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("createdAt").descending());
+        Page<Object[]> productsPage = mypageRepository.getRegisteredProductsByUserId(userId, pageable);
+
+        return productsPage.map(this::arrayToProductResponseDto);
+    }
+
+    // 판매 이력 조회 (최신 판매 순)
+    @Transactional
+    public Page<ProductResponseDto> getSoldProductsByMemberId(Long userId, int pageNumber, int pageSize){
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("createdAt").descending());
+        Page<Object[]> productsPage = mypageRepository.getSoldProductsByMemberId(userId, pageable);
+
+        return productsPage.map(this::arrayToProductResponseDto);
     }
 }
 

--- a/backend/src/main/java/com/woochacha/backend/domain/product/entity/Product.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/entity/Product.java
@@ -36,9 +36,6 @@ public class Product {
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
     private LocalDateTime updatedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
## 구현 기능
- 구현 기능을 적어주세요. 

마이페이지에서 판매 내역을 조회하는 기능

## 관련 이슈

- Close #39 

## 세부 작업 내용

- [x] DB에 dummy data 생성
- [x] 판매 조회 관련 로직 작성 (JPQL 활용)
- [x] 페이지네이션 구현
- [x] postman 테스트

## 참고 사항

- 리뷰어에게 참고할만한 사항을 입력해주세요.

[페이지네이션 관련]
- 페이지는 0부터 시작되고 페이지당 5개씩 데이터를 보여주고, 최신 게시글 순으로 정렬하게 구현했습니다.
- TODO : 최신 게시글 순 -> 판매일 순으로 향후 리팩토링 할 예정입니다.

- 다른 테이블에서 참조할 수 없는 단방향 매핑 테이블이 두개가 있어 (CarImage, Transaction) Product, CarImage를 양방향 매핑으로 변경하였습니다. 

- 구현 API : /mypage/sale/{user_id}

[프론트에 보낼 데이터 예시]
<img width="742" alt="image" src="https://github.com/woorifisa-projects/woochacha/assets/61819350/75f9bfed-7a36-4713-9646-b59408282740">


