### PR TITLE
[feat] 백엔드 마이페이지 구매이력 조회

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/controller/MypageController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/controller/MypageController.java
@@ -27,4 +27,30 @@ public class MypageController {
         Page<ProductResponseDto> productsPage = mypageService.getRegisteredProductsByUserId(user_id, page, size);
         return ResponseEntity.ok(productsPage);
     }
+
+    /*
+     [마이페이지 - 판매 이력 조회]
+     반환 데이터 : "carName", "imageUrl", "price", "year", "distance", "branch", "createdAt"
+     페이지네이션 : 한 페이지당 5개, 게시글 작성일 최신순으로 정렬
+     */
+    @GetMapping("/sale/{user_id}")
+    public ResponseEntity<Page<ProductResponseDto>> soldProduct(@PathVariable Long user_id,
+                                                                @RequestParam(defaultValue = "0") int page,
+                                                                @RequestParam(defaultValue = "5") int size){
+        Page<ProductResponseDto> productsPage = mypageService.getSoldProductsByMemberId(user_id, page, size);
+        return ResponseEntity.ok(productsPage);
+    }
+
+    /*
+     [마이페이지 - 구매 이력 조회]
+     반환 데이터 : "carName", "imageUrl", "price", "year", "distance", "branch", "createdAt"
+     페이지네이션 : 한 페이지당 5개, 게시글 작성일 최신순으로 정렬
+     */
+    @GetMapping("/purchase/{user_id}")
+    public ResponseEntity<Page<ProductResponseDto>> purchaseProduct(@PathVariable Long user_id,
+                                                                    @RequestParam(defaultValue = "0") int page,
+                                                                    @RequestParam(defaultValue = "5") int size) {
+        Page<ProductResponseDto> productsPage = mypageService.getPurchaseProductsByMemberId(user_id, page, size);
+        return ResponseEntity.ok(productsPage);
+    }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/repository/MypageRepository.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/repository/MypageRepository.java
@@ -25,6 +25,37 @@ public interface MypageRepository extends JpaRepository<SaleForm, Long> {
             "WHERE p2.id = p.id AND p2.createdAt < p.createdAt)" +
             "GROUP BY cd.carName, cd.year, cd.distance, sf.branch.id, p.createdAt, p.id")
     Page<Object[]> getRegisteredProductsByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    // TODO: createAt을 게시글 등록일이 아닌 판매일로 수정 (transaction 테이블) -> 양방향 매핑으로 수정
+    // 마이페이지 - 판매 이력 조회 (product.id가 같은 행은 하나만(첫 번째 행) 출력)
+    @Query("SELECT cd.carName, ci.imageUrl, p.price, cd.year, cd.distance, sf.branch, p.createdAt "  +
+            "FROM CarImage ci " +
+            "JOIN ci.product p " +
+            "JOIN p.carDetail cd " +
+            "JOIN p.saleForm sf " +
+            "JOIN sf.member m "  +
+            "WHERE m.id = :userId AND p.status.id = 5 " +
+            "AND NOT EXISTS(" +
+            "SELECT 1 FROM Product p2 " +
+            "WHERE p2.id = p.id AND p2.createdAt < p.createdAt) " +
+            "GROUP BY cd.carName, cd.year, cd.distance, sf.branch.id, p.createdAt, p.id")
+    Page<Object[]> getSoldProductsByMemberId(@Param("userId") Long userId, Pageable pageable);
+
+    // TODO: dummy data 추가로 넣어서 확인
+    // 마이페이지 - 구매 이력 조회
+    @Query("SELECT cd.carName, ci.imageUrl, p.price, cd.year, cd.distance, sf.branch, tr.createdAt " +
+            "FROM Transaction tr " +
+            "JOIN tr.purchaseForm pf " +
+            "JOIN tr.saleForm sf " +
+            "JOIN pf.product p " +
+            "JOIN p.carDetail cd " +
+            "JOIN p.transactionList ci " +
+            "WHERE tr.purchaseForm.member.id = :userId " +
+            "AND NOT EXISTS (" +
+            "SELECT 1 FROM Product p2 " +
+            "WHERE p2.id = p.id AND p2.createdAt < p.createdAt) " +
+            "GROUP BY p.id ")
+    Page<Object[]> getPurchaseProductsByMemberId(@Param("userId") Long userId, Pageable pageable);
 }
 
 

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
@@ -22,15 +22,6 @@ public class MypageServiceImpl implements MypageService {
         this.mypageRepository = mypageRepository;
     }
 
-    // 페이지네이션 : 한 페이지당 5개, 게시글 작성일 최신순으로 정렬
-    @Transactional
-    public Page<ProductResponseDto> getRegisteredProductsByUserId(Long userId, int pageNumber, int pageSize) {
-        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("createdAt").descending());
-        Page<Object[]> productsPage = mypageRepository.getRegisteredProductsByUserId(userId, pageable);
-
-        return productsPage.map(this::arrayToProductResponseDto);
-    }
-
     // JPQL로 조회한 결과 ProductResponseDto로 변환해서 전달
     private ProductResponseDto arrayToProductResponseDto(Object[] array) {
         CarName carName = (CarName) array[0];
@@ -43,6 +34,33 @@ public class MypageServiceImpl implements MypageService {
                 (Branch) array[5],
                 (LocalDateTime) array[6]
         );
+    }
+
+    // 등록한 매물 조회 (최신 등록 순)
+    @Transactional
+    public Page<ProductResponseDto> getRegisteredProductsByUserId(Long userId, int pageNumber, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("createdAt").descending());
+        Page<Object[]> productsPage = mypageRepository.getRegisteredProductsByUserId(userId, pageable);
+
+        return productsPage.map(this::arrayToProductResponseDto);
+    }
+
+    // 판매 이력 조회 (최신 판매 순)
+    @Transactional
+    public Page<ProductResponseDto> getSoldProductsByMemberId(Long userId, int pageNumber, int pageSize){
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("createdAt").descending());
+        Page<Object[]> productsPage = mypageRepository.getSoldProductsByMemberId(userId, pageable);
+
+        return productsPage.map(this::arrayToProductResponseDto);
+    }
+
+    // 구매 이력 조회 (최신 구매 순)
+    @Transactional
+    public Page<ProductResponseDto> getPurchaseProductsByMemberId(Long userId, int pageNumber, int pageSize){
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("createdAt").descending());
+        Page<Object[]> productsPage = mypageRepository.getPurchaseProductsByMemberId(userId, pageable);
+
+        return productsPage.map(this::arrayToProductResponseDto);
     }
 }
 

--- a/backend/src/main/java/com/woochacha/backend/domain/product/entity/Product.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/entity/Product.java
@@ -1,5 +1,6 @@
 package com.woochacha.backend.domain.product.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.woochacha.backend.domain.car.detail.entity.CarDetail;
 import com.woochacha.backend.domain.sale.entity.SaleForm;
 import com.woochacha.backend.domain.status.entity.CarStatus;
@@ -14,6 +15,8 @@ import org.hibernate.annotations.UpdateTimestamp;
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -36,9 +39,6 @@ public class Product {
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
     private LocalDateTime updatedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -48,4 +48,8 @@ public class Product {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "car_num")
     private CarDetail carDetail;
+
+    @OneToMany(mappedBy = "product") // Transaction 엔티티와의 양방향 관계 설정
+    @JsonIgnore
+    private List<CarImage> transactionList = new ArrayList<>();
 }


### PR DESCRIPTION
## 구현 기능

- 구현 기능을 적어주세요.
마이페이지에서 사용자가 자신이 구매한 매물을 조회하는 기능 구현

## 관련 이슈

- Close #43 

## 세부 작업 내용

- [x]  DB에 dummy data 생성 
- [x] 구매 조회 관련 로직 작성 (JPQL 활용)
- [x]  페이지네이션 구현
- [x]  postman 테스트

## 참고 사항

- 리뷰어에게 참고할만한 사항을 입력해주세요.
- 
[페이지네이션 관련]

- 페이지는 0부터 시작되고 페이지당 5개씩 데이터를 보여주고, 최신 구매일부터 정렬하도록 구현했습니다.

- 다른 테이블에서 참조할 수 없는 단방향 매핑 테이블이 두개가 있어 (CarImage, Transaction) Product, CarImage를 양방향 매핑으로 변경하였습니다.

- 구현 API : /mypage/purchase/{user_id}

[프론트에 보낼 데이터 예시]
<img width="675" alt="image" src="https://github.com/woorifisa-projects/woochacha/assets/61819350/2b72f1ec-8eec-4981-82b5-078ad9197156">


