### PR TITLE
[chore] DB에서 BIT 타입의 컬럼을 TINYINT로 수정 및 백엔드 엔티티에 반영

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/car/detail/entity/CarOption.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/detail/entity/CarOption.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.NotNull;
 
 @Entity
 @Getter
@@ -19,26 +18,26 @@ public class CarOption {
     private CarDetail carDetail;
 
     @NotNull
-    private Boolean heatedSeat;
+    private Byte heatedSeat;
 
     @NotNull
-    private Boolean smartKey;
+    private Byte smartKey;
 
     @NotNull
-    private Boolean blackbox;
+    private Byte blackbox;
 
     @NotNull
-    private Boolean navigation;
+    private Byte navigation;
 
     @NotNull
-    private Boolean airbag;
+    private Byte airbag;
 
     @NotNull
-    private Boolean sunroof;
+    private Byte sunroof;
 
     @NotNull
-    private Boolean highPass;
+    private Byte highPass;
 
     @NotNull
-    private Boolean rearviewCamera;
+    private Byte rearviewCamera;
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/entity/Member.java
@@ -31,8 +31,7 @@ public class Member implements UserDetails {
     private Long id;
 
     @ColumnDefault("1")
-//    @NotNull
-    private Boolean role;
+    private Byte role;
 
     @NotNull
     private String email;
@@ -53,10 +52,10 @@ public class Member implements UserDetails {
     private LocalDateTime updatedAt;
 
     @ColumnDefault("1")
-    private Boolean isAvailable;
+    private Byte isAvailable;
 
     @ColumnDefault("1")
-    private Boolean status;
+    private Byte status;
 
     private String profileImage;
 

--- a/backend/src/main/java/com/woochacha/backend/domain/purchase/entity/PurchaseForm.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/purchase/entity/PurchaseForm.java
@@ -37,5 +37,5 @@ public class PurchaseForm {
 
     @ColumnDefault("0")
     @NotNull
-    private Boolean status;
+    private Byte status;
 }


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- DB에서 BIT 타입의 컬럼을 TINYINT로 수정
- 백엔드 엔티티 컬럼 중 Boolean 타입을 Byte로 수정

## 관련 이슈

- Close #51
## 세부 작업 내용

- [ ] DB의 car_option, member, purchase_form 테이블의 BIT 타입을 가진 컬럼을 TINYINT(1)로 수정
- [ ] 백엔드 엔티티에서 Boolean 타입으로 매핑되어있던 컬럼을 Byte로 수정

## 참고 사항

- MySQL의 BIT 타입은 1 ~ 127의 범위를 가져, 0을 저장할 수 없습니다. 따라서 상태나 여부 등의 표현을 보다 직관적으로 나타내기 위해 0과 1을 모두 나타낼 수 있는 타입 중 가장 작은 TINYINT타입을 적용하였습니다. TINYINT(n)의 범위는 -128 ~ 127이며, 여기서 n은 ZEROFILL 옵션에 사용됩니다. 이 옵션은 입력 데이터가 n의 자릿수보다 작은 경우, 비어있는 자릿소는 0으로 채운다는 의미입니다. 만약 n이 5이고, 저장할 데이터는 1이라면 실제로 DB에는 "00001"로 저장되게 됩니다.
- Java의 Byte 범위는 -128~127입니다.