### PR TITLE
[feat] 백엔드 프로필 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/repository/MemberRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
+
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/controller/MypageController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/controller/MypageController.java
@@ -1,6 +1,7 @@
 package com.woochacha.backend.domain.mypage.controller;
 
 import com.woochacha.backend.domain.mypage.dto.ProductResponseDto;
+import com.woochacha.backend.domain.mypage.dto.ProfileDto;
 import com.woochacha.backend.domain.mypage.service.impl.MypageServiceImpl;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -53,5 +54,15 @@ public class MypageController {
                                                                     @RequestParam(defaultValue = "5") int size) {
         Page<ProductResponseDto> productsPage = mypageService.getPurchaseProductsByMemberId(user_id, page, size);
         return ResponseEntity.ok(productsPage);
+    }
+
+    /*
+    [마이페이지 프로필 조회]
+    반환 데이터 : "profileImage", "name", "phone", "email"
+     */
+    @GetMapping("/{user_id}")
+    public ResponseEntity<ProfileDto> mapage(@PathVariable Long user_id){
+        ProfileDto profileDto = mypageService.getProfileByMemberId(user_id);
+        return ResponseEntity.ok(profileDto);
     }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/controller/MypageController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/controller/MypageController.java
@@ -13,7 +13,7 @@ public class MypageController {
 
     private final MypageServiceImpl mypageService;
 
-    public MypageController(MypageServiceImpl mypageService) {
+    private MypageController(MypageServiceImpl mypageService) {
         this.mypageService = mypageService;
     }
 
@@ -22,11 +22,11 @@ public class MypageController {
     반환 데이터 : "carName", "imageUrl", "price", "year", "distance", "branch", "createdAt"
     페이지네이션 : 한 페이지당 5개, 게시글 작성일 최신순으로 정렬
     */
-    @GetMapping("/registered/{user_id}")
-    public ResponseEntity<Page<ProductResponseDto>> registeredProduct(@PathVariable Long user_id,
+    @GetMapping("/registered/{memberId}")
+    private ResponseEntity<Page<ProductResponseDto>> registeredProduct(@PathVariable Long memberId,
                                                                       @RequestParam(defaultValue = "0") int page,
                                                                       @RequestParam(defaultValue = "5") int size) {
-        Page<ProductResponseDto> productsPage = mypageService.getRegisteredProductsByUserId(user_id, page, size);
+        Page<ProductResponseDto> productsPage = mypageService.getRegisteredProductsByUserId(memberId, page, size);
         return ResponseEntity.ok(productsPage);
     }
 
@@ -35,11 +35,11 @@ public class MypageController {
      반환 데이터 : "carName", "imageUrl", "price", "year", "distance", "branch", "createdAt"
      페이지네이션 : 한 페이지당 5개, 게시글 작성일 최신순으로 정렬
      */
-    @GetMapping("/sale/{user_id}")
-    public ResponseEntity<Page<ProductResponseDto>> soldProduct(@PathVariable Long user_id,
+    @GetMapping("/sale/{memberId}")
+    private ResponseEntity<Page<ProductResponseDto>> soldProduct(@PathVariable Long memberId,
                                                                 @RequestParam(defaultValue = "0") int page,
                                                                 @RequestParam(defaultValue = "5") int size){
-        Page<ProductResponseDto> productsPage = mypageService.getSoldProductsByMemberId(user_id, page, size);
+        Page<ProductResponseDto> productsPage = mypageService.getSoldProductsByMemberId(memberId, page, size);
         return ResponseEntity.ok(productsPage);
     }
 
@@ -48,11 +48,11 @@ public class MypageController {
      반환 데이터 : "carName", "imageUrl", "price", "year", "distance", "branch", "createdAt"
      페이지네이션 : 한 페이지당 5개, 게시글 작성일 최신순으로 정렬
      */
-    @GetMapping("/purchase/{user_id}")
-    public ResponseEntity<Page<ProductResponseDto>> purchaseProduct(@PathVariable Long user_id,
+    @GetMapping("/purchase/{memberId}")
+    private ResponseEntity<Page<ProductResponseDto>> purchaseProduct(@PathVariable Long memberId,
                                                                     @RequestParam(defaultValue = "0") int page,
                                                                     @RequestParam(defaultValue = "5") int size) {
-        Page<ProductResponseDto> productsPage = mypageService.getPurchaseProductsByMemberId(user_id, page, size);
+        Page<ProductResponseDto> productsPage = mypageService.getPurchaseProductsByMemberId(memberId, page, size);
         return ResponseEntity.ok(productsPage);
     }
 
@@ -60,9 +60,9 @@ public class MypageController {
     [마이페이지 프로필 조회]
     반환 데이터 : "profileImage", "name", "phone", "email"
      */
-    @GetMapping("/{user_id}")
-    public ResponseEntity<ProfileDto> mapage(@PathVariable Long user_id){
-        ProfileDto profileDto = mypageService.getProfileByMemberId(user_id);
+    @GetMapping("/{memberId}")
+    private ResponseEntity<ProfileDto> mapage(@PathVariable Long memberId){
+        ProfileDto profileDto = mypageService.getProfileByMemberId(memberId);
         return ResponseEntity.ok(profileDto);
     }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/ProductResponseDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/ProductResponseDto.java
@@ -2,19 +2,20 @@ package com.woochacha.backend.domain.mypage.dto;
 
 import com.woochacha.backend.domain.sale.entity.Branch;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
-import javax.persistence.criteria.CriteriaBuilder;
 import java.time.LocalDateTime;
 
 @Data
+@NoArgsConstructor
 public class ProductResponseDto {
 
-    private String carName;
-    private String imageUrl;
-    private Integer price;
-    private Short year;
-    private Integer distance;
-    private Branch branch;
+    private String carName; // 차량명
+    private String imageUrl; // 차량 첫 번째 사진
+    private Integer price; // 차량 가격
+    private Short year; // 연식
+    private Integer distance; // 주행거리
+    private Branch branch; // 차고지 지역
     private LocalDateTime createdAt;
 
     public ProductResponseDto(String carName, String imageUrl, Integer price, Short year, Integer distance, Branch branch, LocalDateTime createdAt) {

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/repository/MypageRepository.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/repository/MypageRepository.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MypageRepository extends JpaRepository<SaleForm, Long> {
 
+    // TODO: 이미지 하나 가져오는 부분 리팩토링
     // 마이페이지 - 등록한 매물 조회
     @Query("SELECT cd.carName, ci.imageUrl, p.price, cd.year, cd.distance, sf.branch, p.createdAt "  +
             "FROM CarImage ci " +
@@ -26,6 +27,7 @@ public interface MypageRepository extends JpaRepository<SaleForm, Long> {
             "GROUP BY cd.carName, cd.year, cd.distance, sf.branch.id, p.createdAt, p.id")
     Page<Object[]> getRegisteredProductsByUserId(@Param("userId") Long userId, Pageable pageable);
 
+    // TODO: 이미지 하나 가져오는 부분 리팩토링
     // TODO: createAt을 게시글 등록일이 아닌 판매일로 수정 (transaction 테이블) -> 양방향 매핑으로 수정
     // 마이페이지 - 판매 이력 조회 (product.id가 같은 행은 하나만(첫 번째 행) 출력)
     @Query("SELECT cd.carName, ci.imageUrl, p.price, cd.year, cd.distance, sf.branch, p.createdAt "  +
@@ -41,6 +43,7 @@ public interface MypageRepository extends JpaRepository<SaleForm, Long> {
             "GROUP BY cd.carName, cd.year, cd.distance, sf.branch.id, p.createdAt, p.id")
     Page<Object[]> getSoldProductsByMemberId(@Param("userId") Long userId, Pageable pageable);
 
+    // TODO: 이미지 하나 가져오는 부분 리팩토링
     // TODO: dummy data 추가로 넣어서 확인
     // 마이페이지 - 구매 이력 조회
     @Query("SELECT cd.carName, ci.imageUrl, p.price, cd.year, cd.distance, sf.branch, tr.createdAt " +

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
@@ -8,18 +8,20 @@ import com.woochacha.backend.domain.mypage.dto.ProfileDto;
 import com.woochacha.backend.domain.mypage.repository.MypageRepository;
 import com.woochacha.backend.domain.mypage.service.MypageService;
 import com.woochacha.backend.domain.sale.entity.Branch;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
-import javax.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.time.LocalDateTime;
 
 @Service
-@AllArgsConstructor
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MypageServiceImpl implements MypageService {
 
     private final MypageRepository mypageRepository;
@@ -40,7 +42,6 @@ public class MypageServiceImpl implements MypageService {
     }
 
     // 등록한 매물 조회 (최신 등록 순)
-    @Transactional
     public Page<ProductResponseDto> getRegisteredProductsByUserId(Long userId, int pageNumber, int pageSize) {
         Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("createdAt").descending());
         Page<Object[]> productsPage = mypageRepository.getRegisteredProductsByUserId(userId, pageable);
@@ -49,7 +50,6 @@ public class MypageServiceImpl implements MypageService {
     }
 
     // 판매 이력 조회 (최신 판매 순)
-    @Transactional
     public Page<ProductResponseDto> getSoldProductsByMemberId(Long userId, int pageNumber, int pageSize){
         Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("createdAt").descending());
         Page<Object[]> productsPage = mypageRepository.getSoldProductsByMemberId(userId, pageable);
@@ -58,7 +58,6 @@ public class MypageServiceImpl implements MypageService {
     }
 
     // 구매 이력 조회 (최신 구매 순)
-    @Transactional
     public Page<ProductResponseDto> getPurchaseProductsByMemberId(Long userId, int pageNumber, int pageSize){
         Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("createdAt").descending());
         Page<Object[]> productsPage = mypageRepository.getPurchaseProductsByMemberId(userId, pageable);

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
@@ -1,10 +1,15 @@
 package com.woochacha.backend.domain.mypage.service.impl;
 
-import com.woochacha.backend.domain.car.detail.entity.CarName;
+import com.woochacha.backend.common.ModelMapping;
+import com.woochacha.backend.domain.member.entity.Member;
+import com.woochacha.backend.domain.member.repository.MemberRepository;
 import com.woochacha.backend.domain.mypage.dto.ProductResponseDto;
+import com.woochacha.backend.domain.mypage.dto.ProfileDto;
 import com.woochacha.backend.domain.mypage.repository.MypageRepository;
 import com.woochacha.backend.domain.mypage.service.MypageService;
 import com.woochacha.backend.domain.sale.entity.Branch;
+import lombok.AllArgsConstructor;
+import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -14,19 +19,17 @@ import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 
 @Service
+@AllArgsConstructor
 public class MypageServiceImpl implements MypageService {
 
-    private MypageRepository mypageRepository;
-
-    public MypageServiceImpl(MypageRepository mypageRepository) {
-        this.mypageRepository = mypageRepository;
-    }
+    private final MypageRepository mypageRepository;
+    private final MemberRepository memberRepository;
+    private final ModelMapper modelMapper = ModelMapping.getInstance();
 
     // JPQL로 조회한 결과 ProductResponseDto로 변환해서 전달
     private ProductResponseDto arrayToProductResponseDto(Object[] array) {
-        CarName carName = (CarName) array[0];
         return new ProductResponseDto(
-                carName.getName(),
+                (String) array[0],
                 (String) array[1],
                 (Integer) array[2],
                 (Short) array[3],
@@ -61,6 +64,12 @@ public class MypageServiceImpl implements MypageService {
         Page<Object[]> productsPage = mypageRepository.getPurchaseProductsByMemberId(userId, pageable);
 
         return productsPage.map(this::arrayToProductResponseDto);
+    }
+
+    // 프로필 조회
+    public ProfileDto getProfileByMemberId(Long userId) {
+        Member member = memberRepository.findById(userId).orElseThrow(() -> new RuntimeException("Member not found"));
+        return modelMapper.map(member, ProfileDto.class);
     }
 }
 


### PR DESCRIPTION
## 구현 기능

마이페이지 - 프로필 조회 기능 구현

## 관련 이슈

- Close #53 

## 세부 작업 내용

- [x] Mypage패키지에서 id로 Member객체를 조회하는 로직 구현
- [x] ProfileDto 생성, ModelMapper 라이브러리를 활용해 ProdileDto생성
- [x] postman 테스트

## 참고 사항

- 구매 이력 조회 일부분 리팩토링 했습니다.

- 프론트 단에 아래와 같은 형식으로 데이터를 전달합니다.
<img width="759" alt="image" src="https://github.com/woorifisa-projects/woochacha/assets/61819350/e4def9a0-f9b0-4644-87e3-3ff7fb2a11d3">
