### PR TITLE
[design] 대출페이지 UI 레이아웃 구성

### DIFF
--- a/frontend/src/components/common/MainCard.js
+++ b/frontend/src/components/common/MainCard.js
@@ -1,0 +1,30 @@
+import { Box, Container, Typography } from '@mui/material';
+import React from 'react';
+
+export default function MainCard({ titleVal, subTitleVal, titleColor }) {
+  return (
+    <Box
+      sx={{
+        bgcolor: 'background.paper',
+        my: 10,
+        pt: 8,
+        pb: 6,
+      }}>
+      <Container maxWidth="md">
+        <Typography
+          component="h3"
+          variant="h3"
+          align="center"
+          fontWeight="bold"
+          color={titleColor}
+          mb={5}
+          gutterBottom>
+          {titleVal}
+        </Typography>
+        <Typography variant="h5" align="center" color="text.secondary" paragraph>
+          {subTitleVal}
+        </Typography>
+      </Container>
+    </Box>
+  );
+}

--- a/frontend/src/components/common/MiniCard.js
+++ b/frontend/src/components/common/MiniCard.js
@@ -1,0 +1,22 @@
+import { Card } from '@mui/material';
+import React from 'react';
+
+export default function MiniCard({ children, colorVal, shadowVal }) {
+  return (
+    <Card
+      sx={{
+        margin: 'auto',
+        backgroundColor: colorVal,
+        boxShadow: shadowVal,
+        py: 8,
+        px: 8,
+        my: 25,
+        height: '100%',
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+      }}>
+      {children}
+    </Card>
+  );
+}

--- a/frontend/src/constants/string.js
+++ b/frontend/src/constants/string.js
@@ -66,4 +66,44 @@ export const HEADER_LOGIN_USER_MENU = {
     },
   ],
 };
-// 파일명 변경을 위한 임시 주석 추가
+
+// 대출
+export const CAPITAL_MAIN_CARD = [
+  {
+    title: `합리적인 자동차 금융상품을 추천해드립니다.`,
+    content: `우차차가 추천하는 최대한도, 최저금리 상품을 소개합니다!`,
+    titleColor: '#000',
+  },
+];
+
+export const CAPITAL_CONTENTS = [
+  {
+    miniCardColor: '#DEF2FF',
+    miniCardShadow: 0,
+    capitalTitle: '리스/렌트 견적 비교',
+    capitalImgUrl:
+      'https://s7d1.scene7.com/is/image/hyundai/2023-ioniq-6-limited-rwd-transmission-blue-pearl-profile:Vehicle-Carousel?fmt=webp-alpha',
+    capitalSubTitle: '리스와 렌트의 견적이 궁금하다면?',
+    capitalSubContent: `내가 원하는 차량의 리스와 렌트의 견적을 비교해드립니다.`,
+    wonCarUrl: 'https://www.wooriwoncar.com/myPage/myCarCompare',
+  },
+  {
+    miniCardColor: '#EFFBFF',
+    miniCardShadow: 0,
+    capitalTitle: '나의 대출한도 확인하기',
+    capitalImgUrl: 'https://www.wooriwoncar.com/webassets/img/pc/main-loan-img1.png',
+    capitalSubTitle: '나의 대출한도를 \n 확인하고 싶다면?',
+    capitalSubContent: `우리 WON카에서는 우리은행, 카드, 캐피탈 3사의
+    최대 대출한도 및 최저금리를 모아서 알려드립니다.`,
+    wonCarUrl: 'https://www.wooriwoncar.com/loanlimit/loanLimitInfo?cpcrGdDivCd=20',
+  },
+  {
+    miniCardColor: '#FFF',
+    miniCardShadow: 0,
+    capitalTitle: '중고차 금융상품',
+    capitalImgUrl: 'https://www.wooriwoncar.com/webassets/img/pc/sd-visual-new-bg.png',
+    capitalSubTitle: '중고차 금융상품이 궁금하다면?',
+    capitalSubContent: `우리 WON카에서 제공하는 최대한도, 최저금리 상품을 추천해드립니다.`,
+    wonCarUrl: 'https://www.wooriwoncar.com/loangoods/loanGoods?loanType=20',
+  },
+];

--- a/frontend/src/pages/capitals/index.js
+++ b/frontend/src/pages/capitals/index.js
@@ -69,8 +69,12 @@ export default function Capitals() {
                         gutterBottom>
                         {item.capitalSubTitle}
                       </Typography>
-                      <Typography sx={{ mb: '10rem' }}>{item.capitalSubContent}</Typography>
-                      <Button href={item.wonCarUrl} variant="contained" fullWidth>
+                      <Typography sx={{ mb: '5rem' }}>{item.capitalSubContent}</Typography>
+                      <Button
+                        href={item.wonCarUrl}
+                        variant="contained"
+                        fullWidth
+                        sx={{ fontSize: '1.3rem' }}>
                         보러가기
                       </Button>
                     </Box>

--- a/frontend/src/pages/capitals/index.js
+++ b/frontend/src/pages/capitals/index.js
@@ -1,5 +1,86 @@
-import React from 'react';
+import {
+  responsiveFontSizes,
+  ThemeProvider,
+  CssBaseline,
+  Box,
+  Typography,
+  Button,
+} from '@mui/material';
+import theme from '@/styles/theme';
+import MainCard from '@/components/common/MainCard';
+import MiniCard from '@/components/common/MiniCard';
+import { CAPITAL_MAIN_CARD, CAPITAL_CONTENTS } from '@/constants/string';
 
 export default function Capitals() {
-  return <div>대출 페이지</div>;
+  let responsiveFontTheme = responsiveFontSizes(theme);
+
+  return (
+    <ThemeProvider theme={responsiveFontTheme}>
+      <CssBaseline />
+      {/* main page */}
+      <main>
+        {/* 페이지 상단 box */}
+        {CAPITAL_MAIN_CARD.map((item, idx) => {
+          return (
+            <MainCard
+              titleVal={item.title}
+              subTitleVal={item.content}
+              titleColor={item.titleColor}
+              key={idx}
+            />
+          );
+        })}
+        {/* 대출 관련 content */}
+        {CAPITAL_CONTENTS.map((item) => {
+          return (
+            <>
+              <MiniCard colorVal={item.miniCardColor} shadowVal={item.miniCardShadow}>
+                <Typography
+                  mb={10}
+                  component="h4"
+                  variant="h4"
+                  color="#1490ef"
+                  fontWeight="bold"
+                  gutterBottom>
+                  {item.capitalTitle}
+                </Typography>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                  }}>
+                  <img width="40%" src={item.capitalImgUrl} />
+                  <Box
+                    sx={{
+                      width: '40%',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'flex-start',
+                    }}>
+                    <Box>
+                      <Typography
+                        mb={4}
+                        component="h4"
+                        variant="h4"
+                        color="inherit"
+                        fontWeight="bold"
+                        gutterBottom>
+                        {item.capitalSubTitle}
+                      </Typography>
+                      <Typography sx={{ mb: '10rem' }}>{item.capitalSubContent}</Typography>
+                      <Button href={item.wonCarUrl} variant="contained" fullWidth>
+                        보러가기
+                      </Button>
+                    </Box>
+                  </Box>
+                </Box>
+              </MiniCard>
+            </>
+          );
+        })}
+      </main>
+    </ThemeProvider>
+  );
 }


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- 대출페이지의 기본적인 UI 레이아웃을 구성

## 관련 이슈

- Close #60 

## 세부 작업 내용

- [x] 대출 메인 페이지
- [x] 링크로 해당 경로로 이동

## 참고 사항

- [우리원카](https://www.wooriwoncar.com/) 페이지를 참고하여 구성했습니다. 좋은 의견 있다면 추가적으로 의견 남겨주세요!
- 구현 화면
![capitals-page03](https://github.com/woorifisa-projects/woochacha/assets/81960250/5305e01d-8b26-46d8-a211-63933dd8ea09)


