### PR TITLE
[feat]] QLDB 환경 셋팅 및 QLDB 기본 조회 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -34,6 +34,11 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation 'org.modelmapper:modelmapper:2.3.0'
 
+	implementation 'com.amazonaws:aws-java-sdk-qldb:1.12.7'
+	implementation 'software.amazon.ion:ion-java:1.5.1'
+	implementation 'software.amazon.qldb:amazon-qldb-driver-java:2.3.1'
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-ion:2.12.1'
+
 	implementation 'org.slf4j:jcl-over-slf4j:'
 
 	implementation 'com.querydsl:querydsl-core'

--- a/backend/src/main/java/com/woochacha/backend/config/QldbConfig.java
+++ b/backend/src/main/java/com/woochacha/backend/config/QldbConfig.java
@@ -1,0 +1,45 @@
+package com.woochacha.backend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.qldbsession.QldbSessionClient;
+import software.amazon.qldb.QldbDriver;
+import software.amazon.qldb.RetryPolicy;
+
+@Configuration
+public class QldbConfig {
+    @Value("${ledger.name}")
+    private String ledgerName;
+
+    @Value("${aws.db.access.key}")
+    private String accessKeyId;
+
+    @Value("${aws.db.secret.key}")
+    private String secretAccessKey;
+
+    @Value("${aws.db.region}")
+    private String region;
+
+    @Bean
+    public QldbDriver QldbDriver(){
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKeyId, secretAccessKey);
+        AwsCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(credentials);
+        return QldbDriver.builder()
+                .ledger(ledgerName)
+                .transactionRetryPolicy(RetryPolicy
+                        .builder()
+                        .maxRetries(3)
+                        .build())
+                .sessionClientBuilder(QldbSessionClient.builder()
+                        .region(Region.of(region))
+                        .credentialsProvider(credentialsProvider)
+                )
+                .build();
+    }
+
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/ProfileDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/ProfileDto.java
@@ -1,0 +1,21 @@
+package com.woochacha.backend.domain.mypage.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class ProfileDto {
+
+    private String profileImage;
+    private String email;
+    private String name;
+    private String phone;
+
+    public ProfileDto(String profileImage, String email, String name, String phone) {
+        this.profileImage = profileImage;
+        this.email = email;
+        this.name = name;
+        this.phone = phone;
+    }
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/purchase/entity/PurchaseForm.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/purchase/entity/PurchaseForm.java
@@ -11,6 +11,7 @@ import org.hibernate.annotations.DynamicInsert;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -32,10 +33,10 @@ public class PurchaseForm {
     private Member member;
 
     @CreationTimestamp
-    @NotNull
     private LocalDateTime createdAt;
 
+    private LocalDate meetingDate;
+
     @ColumnDefault("0")
-    @NotNull
     private Byte status;
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/qldb/service/QldbService.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/qldb/service/QldbService.java
@@ -6,4 +6,7 @@ public interface QldbService {
     Pair<String, String> inquiryCarOwnerInfo(String carNum);
 
     String getMetaIdValue(String carNum, String tableName);
+
+    // QLDB에 저장된 history를 차량 번호에 따른 차량 사고 종류와 사고 내역에 대해서 일치하는 history의 개수를 count한다.
+    int accidentHistoryInfo(String carNum, String metaId, String accidentType, String accidentDesc);
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/qldb/service/QldbService.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/qldb/service/QldbService.java
@@ -5,4 +5,5 @@ import org.springframework.data.util.Pair;
 public interface QldbService {
     Pair<String, String> inquiryCarOwnerInfo(String carNum);
 
+    String getMetaIdValue(String carNum, String tableName);
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/qldb/service/QldbService.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/qldb/service/QldbService.java
@@ -1,0 +1,8 @@
+package com.woochacha.backend.domain.qldb.service;
+
+import org.springframework.data.util.Pair;
+
+public interface QldbService {
+    Pair<String, String> inquiryCarOwnerInfo(String carNum);
+
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/qldb/service/serviceImpl/QldbServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/qldb/service/serviceImpl/QldbServiceImpl.java
@@ -1,0 +1,40 @@
+package com.woochacha.backend.domain.qldb.service.serviceImpl;
+
+import com.amazon.ion.IonString;
+import com.amazon.ion.IonStruct;
+import com.amazon.ion.IonSystem;
+import com.amazon.ion.system.IonSystemBuilder;
+import com.woochacha.backend.config.QldbConfig;
+import com.woochacha.backend.domain.qldb.service.QldbService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
+import org.springframework.stereotype.Service;
+import software.amazon.qldb.Result;
+
+@Service
+@RequiredArgsConstructor
+public class QldbServiceImpl implements QldbService {
+
+    private final QldbConfig qldbDriver;
+    private String owner;
+    private String ownerPhone;
+
+    @Override
+    public Pair<String,String> inquiryCarOwnerInfo(String carNum) {
+        IonSystem ionSys = IonSystemBuilder.standard().build();
+        try {
+            qldbDriver.QldbDriver().execute(txn -> {
+                Result result = txn.execute(
+                        "SELECT r.car_owner, r.car_owner_phone FROM car AS r WHERE r.car_num=?", ionSys.newString(carNum));
+                IonStruct carOwner = (IonStruct) result.iterator().next();
+                IonString carOwnerString = (IonString) carOwner.get("car_owner");
+                owner = carOwnerString.stringValue();
+                IonString carOwnerPhoneString = (IonString) carOwner.get("car_owner_phone");
+                ownerPhone = carOwnerPhoneString.stringValue();
+            });
+            return Pair.of(owner,ownerPhone);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/qldb/service/serviceImpl/QldbServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/qldb/service/serviceImpl/QldbServiceImpl.java
@@ -1,5 +1,6 @@
 package com.woochacha.backend.domain.qldb.service.serviceImpl;
 
+import com.amazon.ion.IonInt;
 import com.amazon.ion.IonString;
 import com.amazon.ion.IonStruct;
 import com.amazon.ion.IonSystem;
@@ -16,14 +17,16 @@ import software.amazon.qldb.Result;
 public class QldbServiceImpl implements QldbService {
 
     private final QldbConfig qldbDriver;
+    private final IonSystem ionSys = IonSystemBuilder.standard().build();
     private String owner;
     private String ownerPhone;
     private String metaId;
+    private int countAccidentHistory;
+
 
     // QLDB에 저장된 차량 번호와 같은 차량 소유주의 이름과 전화번호를 찾아준다.
     @Override
     public Pair<String,String> inquiryCarOwnerInfo(String carNum) {
-        IonSystem ionSys = IonSystemBuilder.standard().build();
         try {
             qldbDriver.QldbDriver().execute(txn -> {
                 Result result = txn.execute(
@@ -43,7 +46,6 @@ public class QldbServiceImpl implements QldbService {
     // QLDB에 저장된 게시글의 history를 볼 수 있는 meta id 값을 가지고 옴
     @Override
     public String getMetaIdValue(String carNum, String tableName) {
-        IonSystem ionSys = IonSystemBuilder.standard().build();
         try {
             qldbDriver.QldbDriver().execute(txn -> {
                 Result result = txn.execute(
@@ -53,6 +55,24 @@ public class QldbServiceImpl implements QldbService {
                 metaId = carMetaId.stringValue();
             });
             return metaId;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // QLDB에 저장된 history를 차량 번호에 따른 차량 사고 종류와 사고 내역에 대해서 일치하는 history의 개수를 count한다.
+    @Override
+    public int accidentHistoryInfo(String carNum, String metaId, String accidentType, String accidentDesc) {
+        try {
+            qldbDriver.QldbDriver().execute(txn -> {
+                Result result = txn.execute(
+                        "SELECT COUNT(*) FROM car AS r WHERE r.car_num=? AND r.accident_type=? AND r.accident_desc =? AND r.metadata.id =?",
+                        ionSys.newString(carNum), ionSys.newString(accidentType), ionSys.newString(accidentDesc), ionSys.newString(metaId));
+                IonStruct countHistory = (IonStruct) result.iterator().next();
+                IonInt countHistoryInt = (IonInt) countHistory.get("_1");
+                countAccidentHistory = countHistoryInt.intValue();
+            });
+            return countAccidentHistory;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/backend/src/main/java/com/woochacha/backend/domain/qldb/service/serviceImpl/QldbServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/qldb/service/serviceImpl/QldbServiceImpl.java
@@ -18,7 +18,9 @@ public class QldbServiceImpl implements QldbService {
     private final QldbConfig qldbDriver;
     private String owner;
     private String ownerPhone;
+    private String metaId;
 
+    // QLDB에 저장된 차량 번호와 같은 차량 소유주의 이름과 전화번호를 찾아준다.
     @Override
     public Pair<String,String> inquiryCarOwnerInfo(String carNum) {
         IonSystem ionSys = IonSystemBuilder.standard().build();
@@ -33,6 +35,24 @@ public class QldbServiceImpl implements QldbService {
                 ownerPhone = carOwnerPhoneString.stringValue();
             });
             return Pair.of(owner,ownerPhone);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // QLDB에 저장된 게시글의 history를 볼 수 있는 meta id 값을 가지고 옴
+    @Override
+    public String getMetaIdValue(String carNum, String tableName) {
+        IonSystem ionSys = IonSystemBuilder.standard().build();
+        try {
+            qldbDriver.QldbDriver().execute(txn -> {
+                Result result = txn.execute(
+                        "SELECT r_id FROM " + tableName + " AS r BY r_id WHERE r.car_num=?", ionSys.newString(carNum));
+                IonStruct carOwner = (IonStruct) result.iterator().next();
+                IonString carMetaId = (IonString) carOwner.get("r_id");
+                metaId = carMetaId.stringValue();
+            });
+            return metaId;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/backend/src/main/java/com/woochacha/backend/domain/status/entity/CarStatusList.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/status/entity/CarStatusList.java
@@ -1,6 +1,6 @@
 package com.woochacha.backend.domain.status.entity;
 
 public enum CarStatusList {
-    반려, 심사중, 심사완료, 판매중, 판매완료, 삭제접수, 완료, 삭제승인완료, 비공개
+    반려, 심사중, 심사완료, 판매중, 판매완료, 삭제접수완료, 삭제승인완료, 비공개
 }
 


### PR DESCRIPTION
## 구현 기능

- AWS QLDB 연결을 위한 기본 환경 셋팅 및 QLDB 조회 코드 구현

## 관련 이슈

- Close #64 

## 세부 작업 내용

- [x] QLDB에 환경 설정
- [x] QLDB에 저장된 차량 소유주와 소유주의 전화번호 조회 기능 구현
- [x] QLDB에 저장된 차량 history를 조회하기 위한 기능 구현
- [x] QLDB에 저장된 history에서 원하는 정보를 조회하기 위한 기능 구현

## 참고 사항

- 각자 aws 액세스 키를 생성하여 직접 프로퍼티에 작성한 후 사용하셔야 합니다.
