### PR TITLE
[chore] 마이페이지 상품 제목 데이터 수정

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/controller/MypageController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/controller/MypageController.java
@@ -3,19 +3,17 @@ package com.woochacha.backend.domain.mypage.controller;
 import com.woochacha.backend.domain.mypage.dto.ProductResponseDto;
 import com.woochacha.backend.domain.mypage.dto.ProfileDto;
 import com.woochacha.backend.domain.mypage.service.impl.MypageServiceImpl;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/mypage")
 public class MypageController {
 
     private final MypageServiceImpl mypageService;
-
-    private MypageController(MypageServiceImpl mypageService) {
-        this.mypageService = mypageService;
-    }
 
     /*
     [마이페이지 - 등록한 매물 조회]
@@ -30,11 +28,11 @@ public class MypageController {
         return ResponseEntity.ok(productsPage);
     }
 
-    /*
-     [마이페이지 - 판매 이력 조회]
-     반환 데이터 : "carName", "imageUrl", "price", "year", "distance", "branch", "createdAt"
-     페이지네이션 : 한 페이지당 5개, 게시글 작성일 최신순으로 정렬
-     */
+//    /*
+//     [마이페이지 - 판매 이력 조회]
+//     반환 데이터 : "carName", "imageUrl", "price", "year", "distance", "branch", "createdAt"
+//     페이지네이션 : 한 페이지당 5개, 게시글 작성일 최신순으로 정렬
+//     */
     @GetMapping("/sale/{memberId}")
     private ResponseEntity<Page<ProductResponseDto>> soldProduct(@PathVariable Long memberId,
                                                                 @RequestParam(defaultValue = "0") int page,
@@ -43,11 +41,11 @@ public class MypageController {
         return ResponseEntity.ok(productsPage);
     }
 
-    /*
-     [마이페이지 - 구매 이력 조회]
-     반환 데이터 : "carName", "imageUrl", "price", "year", "distance", "branch", "createdAt"
-     페이지네이션 : 한 페이지당 5개, 게시글 작성일 최신순으로 정렬
-     */
+//    /*
+//     [마이페이지 - 구매 이력 조회]
+//     반환 데이터 : "carName", "imageUrl", "price", "year", "distance", "branch", "createdAt"
+//     페이지네이션 : 한 페이지당 5개, 게시글 작성일 최신순으로 정렬
+//     */
     @GetMapping("/purchase/{memberId}")
     private ResponseEntity<Page<ProductResponseDto>> purchaseProduct(@PathVariable Long memberId,
                                                                     @RequestParam(defaultValue = "0") int page,
@@ -61,7 +59,7 @@ public class MypageController {
     반환 데이터 : "profileImage", "name", "phone", "email"
      */
     @GetMapping("/{memberId}")
-    private ResponseEntity<ProfileDto> mapage(@PathVariable Long memberId){
+    private ResponseEntity<ProfileDto> mypage(@PathVariable Long memberId){
         ProfileDto profileDto = mypageService.getProfileByMemberId(memberId);
         return ResponseEntity.ok(profileDto);
     }

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/controller/MypageController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/controller/MypageController.java
@@ -16,8 +16,7 @@ public class MypageController {
     private final MypageServiceImpl mypageService;
 
     /*
-    [마이페이지 - 등록한 매물 조회]
-    반환 데이터 : "carName", "imageUrl", "price", "year", "distance", "branch", "createdAt"
+    마이페이지 - 등록한 매물 조회
     페이지네이션 : 한 페이지당 5개, 게시글 작성일 최신순으로 정렬
     */
     @GetMapping("/registered/{memberId}")
@@ -28,11 +27,10 @@ public class MypageController {
         return ResponseEntity.ok(productsPage);
     }
 
-//    /*
-//     [마이페이지 - 판매 이력 조회]
-//     반환 데이터 : "carName", "imageUrl", "price", "year", "distance", "branch", "createdAt"
-//     페이지네이션 : 한 페이지당 5개, 게시글 작성일 최신순으로 정렬
-//     */
+    /*
+     마이페이지 - 판매 이력 조회
+     페이지네이션 : 한 페이지당 5개
+     */
     @GetMapping("/sale/{memberId}")
     private ResponseEntity<Page<ProductResponseDto>> soldProduct(@PathVariable Long memberId,
                                                                 @RequestParam(defaultValue = "0") int page,
@@ -41,11 +39,10 @@ public class MypageController {
         return ResponseEntity.ok(productsPage);
     }
 
-//    /*
-//     [마이페이지 - 구매 이력 조회]
-//     반환 데이터 : "carName", "imageUrl", "price", "year", "distance", "branch", "createdAt"
-//     페이지네이션 : 한 페이지당 5개, 게시글 작성일 최신순으로 정렬
-//     */
+    /*
+     마이페이지 구매 이력 조회
+     페이지네이션 : 한 페이지당 5개
+     */
     @GetMapping("/purchase/{memberId}")
     private ResponseEntity<Page<ProductResponseDto>> purchaseProduct(@PathVariable Long memberId,
                                                                     @RequestParam(defaultValue = "0") int page,
@@ -55,8 +52,7 @@ public class MypageController {
     }
 
     /*
-    [마이페이지 프로필 조회]
-    반환 데이터 : "profileImage", "name", "phone", "email"
+    마이페이지 프로필 조회
      */
     @GetMapping("/{memberId}")
     private ResponseEntity<ProfileDto> mypage(@PathVariable Long memberId){

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/ProductResponseDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/ProductResponseDto.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class ProductResponseDto {
-    private String title; // 제목(model + car_name + year)
+    private String title; // 제목 : 모델+차량명+연식
 
     private Integer distance; // 주행 거리
 

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/ProductResponseDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/ProductResponseDto.java
@@ -1,30 +1,30 @@
 package com.woochacha.backend.domain.mypage.dto;
 
-import com.woochacha.backend.domain.sale.entity.Branch;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Data
 @NoArgsConstructor
+@Builder
 public class ProductResponseDto {
+    private String title; // 제목(model + car_name + year)
 
-    private String carName; // 차량명
-    private String imageUrl; // 차량 첫 번째 사진
-    private Integer price; // 차량 가격
-    private Short year; // 연식
-    private Integer distance; // 주행거리
-    private Branch branch; // 차고지 지역
-    private LocalDateTime createdAt;
+    private Integer distance; // 주행 거리
 
-    public ProductResponseDto(String carName, String imageUrl, Integer price, Short year, Integer distance, Branch branch, LocalDateTime createdAt) {
-        this.carName = carName;
-        this.imageUrl = imageUrl;
-        this.price = price;
-        this.year = year;
+    private String branch; // 지점
+
+    private Integer price; // 가격
+
+    private String imageUrl; // 사진
+
+    public ProductResponseDto(String title, Integer distance, String branch, Integer price, String imageUrl) {
+        this.title = title;
         this.distance = distance;
         this.branch = branch;
-        this.createdAt = createdAt;
+        this.price = price;
+        this.imageUrl = imageUrl;
     }
+
 }
+

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/ProfileDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/ProfileDto.java
@@ -7,10 +7,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ProfileDto {
 
-    private String profileImage;
-    private String email;
-    private String name;
-    private String phone;
+    private String profileImage; // 프로필 사진
+    private String email; // 사용자 이메일
+    private String name; // 사용자 이름
+    private String phone; // 사용자 전화번호
 
     public ProfileDto(String profileImage, String email, String name, String phone) {
         this.profileImage = profileImage;

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/repository/MypageRepository.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/repository/MypageRepository.java
@@ -12,53 +12,60 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MypageRepository extends JpaRepository<SaleForm, Long> {
 
-    // TODO: 이미지 하나 가져오는 부분 리팩토링
     // 마이페이지 - 등록한 매물 조회
-    @Query("SELECT cd.carName, ci.imageUrl, p.price, cd.year, cd.distance, sf.branch, p.createdAt "  +
+    @Query("SELECT " +
+            "CONCAT(CAST(cd.model.name AS string), ' ', cd.carName.name, ' ', CAST(cd.year AS string), '년형') AS title, " +
+            "cd.distance, " +
+            "CAST(sf.branch.name AS string) AS branch, " +
+            "p.price, " +
+            "ci.imageUrl " +
             "FROM CarImage ci " +
             "JOIN ci.product p " +
             "JOIN p.carDetail cd " +
             "JOIN p.saleForm sf " +
-            "JOIN sf.member m "  +
-            "WHERE m.id = :userId AND p.status.id = 4 " +
-            "AND NOT EXISTS(" +
-            "SELECT 1 FROM Product p2 " +
-            "WHERE p2.id = p.id AND p2.createdAt < p.createdAt) " +
-            "GROUP BY cd.carName, cd.year, cd.distance, sf.branch.id, p.createdAt, p.id")
-    Page<Object[]> getRegisteredProductsByUserId(@Param("userId") Long userId, Pageable pageable);
+            "WHERE p.status.id = 4 " +
+            "AND ci.imageUrl LIKE '%/1' " +
+            "AND sf.member.id = :memberId " +
+            "ORDER BY p.createdAt ASC ")
+    Page<Object[]> getRegisteredProductsByUserId(@Param("memberId") Long memberId, Pageable pageable);
 
-    // TODO: 이미지 하나 가져오는 부분 리팩토링
-    // TODO: createAt을 게시글 등록일이 아닌 판매일로 수정 (transaction 테이블) -> 양방향 매핑으로 수정
+//    // TODO: createAt을 게시글 등록일이 아닌 판매일로 수정 (transaction 테이블) -> 양방향 매핑으로 수정
     // 마이페이지 - 판매 이력 조회 (product.id가 같은 행은 하나만(첫 번째 행) 출력)
-    @Query("SELECT cd.carName, ci.imageUrl, p.price, cd.year, cd.distance, sf.branch, p.createdAt "  +
+    @Query("SELECT " +
+            "CONCAT(CAST(cd.model.name AS string), ' ', cd.carName.name, ' ', CAST(cd.year AS string), '년형') AS title, " +
+            "cd.distance, " +
+            "CAST(sf.branch.name AS string) AS branch, " +
+            "p.price, " +
+            "ci.imageUrl " +
             "FROM CarImage ci " +
             "JOIN ci.product p " +
             "JOIN p.carDetail cd " +
             "JOIN p.saleForm sf " +
-            "JOIN sf.member m "  +
-            "WHERE m.id = :userId AND p.status.id = 5 " +
-            "AND NOT EXISTS(" +
-            "SELECT 1 FROM Product p2 " +
-            "WHERE p2.id = p.id AND p2.createdAt < p.createdAt) " +
-            "GROUP BY cd.carName, cd.year, cd.distance, sf.branch.id, p.createdAt, p.id")
-    Page<Object[]> getSoldProductsByMemberId(@Param("userId") Long userId, Pageable pageable);
+            "WHERE p.status.id = 5 " +
+            "AND ci.imageUrl LIKE '%/1' " +
+            "AND sf.member.id = :memberId " +
+            "ORDER BY p.createdAt ASC ")
+    Page<Object[]> getSoldProductsByMemberId(@Param("memberId") Long userId, Pageable pageable);
 
-    // TODO: 이미지 하나 가져오는 부분 리팩토링
-    // TODO: dummy data 추가로 넣어서 확인
-    // 마이페이지 - 구매 이력 조회
-    @Query("SELECT cd.carName, ci.imageUrl, p.price, cd.year, cd.distance, sf.branch, tr.createdAt " +
+//    // TODO: 이미지 하나 가져오는 부분 리팩토링
+//    // TODO: dummy data 추가로 넣어서 확인
+//    // 마이페이지 - 구매 이력 조회
+    @Query("SELECT " +
+            "CONCAT(CAST(cd.model.name AS string), ' ', cd.carName.name, ' ', CAST(cd.year AS string), '년형') AS title, " +
+            "cd.distance, " +
+            "CAST(sf.branch.name AS string) AS branch, " +
+            "p.price, " +
+            "ci.imageUrl " +
             "FROM Transaction tr " +
             "JOIN tr.purchaseForm pf " +
             "JOIN tr.saleForm sf " +
             "JOIN pf.product p " +
             "JOIN p.carDetail cd " +
             "JOIN p.transactionList ci " +
-            "WHERE tr.purchaseForm.member.id = :userId " +
-            "AND NOT EXISTS (" +
-            "SELECT 1 FROM Product p2 " +
-            "WHERE p2.id = p.id AND p2.createdAt < p.createdAt) " +
-            "GROUP BY p.id ")
-    Page<Object[]> getPurchaseProductsByMemberId(@Param("userId") Long userId, Pageable pageable);
+            "WHERE tr.purchaseForm.member.id = :memberId " +
+            "AND ci.imageUrl LIKE '%/1' " +
+            "ORDER BY tr.createdAt ASC ")
+    Page<Object[]> getPurchaseProductsByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 }
 
 

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/repository/MypageRepository.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/repository/MypageRepository.java
@@ -29,8 +29,7 @@ public interface MypageRepository extends JpaRepository<SaleForm, Long> {
             "ORDER BY p.createdAt ASC ")
     Page<Object[]> getRegisteredProductsByUserId(@Param("memberId") Long memberId, Pageable pageable);
 
-//    // TODO: createAt을 게시글 등록일이 아닌 판매일로 수정 (transaction 테이블) -> 양방향 매핑으로 수정
-    // 마이페이지 - 판매 이력 조회 (product.id가 같은 행은 하나만(첫 번째 행) 출력)
+//  마이페이지 - 판매 이력 조회
     @Query("SELECT " +
             "CONCAT(CAST(cd.model.name AS string), ' ', cd.carName.name, ' ', CAST(cd.year AS string), '년형') AS title, " +
             "cd.distance, " +
@@ -47,9 +46,7 @@ public interface MypageRepository extends JpaRepository<SaleForm, Long> {
             "ORDER BY p.createdAt ASC ")
     Page<Object[]> getSoldProductsByMemberId(@Param("memberId") Long userId, Pageable pageable);
 
-//    // TODO: 이미지 하나 가져오는 부분 리팩토링
-//    // TODO: dummy data 추가로 넣어서 확인
-//    // 마이페이지 - 구매 이력 조회
+    // 마이페이지 - 구매 이력 조회
     @Query("SELECT " +
             "CONCAT(CAST(cd.model.name AS string), ' ', cd.carName.name, ' ', CAST(cd.year AS string), '년형') AS title, " +
             "cd.distance, " +

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
@@ -23,7 +23,6 @@ public class MypageServiceImpl implements MypageService {
 
     private final MypageRepository mypageRepository;
     private final MemberRepository memberRepository;
-
     private final ModelMapper modelMapper = ModelMapping.getInstance();
 
     // JPQL로 조회한 결과 ProductResponseDto로 변환해서 전달
@@ -37,7 +36,7 @@ public class MypageServiceImpl implements MypageService {
                 .build();
     }
 
-    // 등록한 매물 조회 (최신 등록 순)
+    // 등록한 매물 조회
     public Page<ProductResponseDto> getRegisteredProductsByUserId(Long userId, int pageNumber, int pageSize) {
         Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("createdAt").descending());
         Page<Object[]> productsPage = mypageRepository.getRegisteredProductsByUserId(userId, pageable);
@@ -45,15 +44,15 @@ public class MypageServiceImpl implements MypageService {
         return productsPage.map(this::arrayToProductResponseDto);
     }
 
-    // 판매 이력 조회 (최신 판매 순)
+    // 판매 이력 조회
     public Page<ProductResponseDto> getSoldProductsByMemberId(Long userId, int pageNumber, int pageSize){
         Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("createdAt").descending());
         Page<Object[]> productsPage = mypageRepository.getSoldProductsByMemberId(userId, pageable);
 
         return productsPage.map(this::arrayToProductResponseDto);
     }
-//
-//    // 구매 이력 조회 (최신 구매 순)
+
+    // 구매 이력 조회
     public Page<ProductResponseDto> getPurchaseProductsByMemberId(Long memberId, int pageNumber, int pageSize){
         Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("createdAt").descending());
         Page<Object[]> productsPage = mypageRepository.getPurchaseProductsByMemberId(memberId, pageable);

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
@@ -7,7 +7,6 @@ import com.woochacha.backend.domain.mypage.dto.ProductResponseDto;
 import com.woochacha.backend.domain.mypage.dto.ProfileDto;
 import com.woochacha.backend.domain.mypage.repository.MypageRepository;
 import com.woochacha.backend.domain.mypage.service.MypageService;
-import com.woochacha.backend.domain.sale.entity.Branch;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Page;
@@ -17,28 +16,25 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-
 @Service
-@RequiredArgsConstructor
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class MypageServiceImpl implements MypageService {
 
     private final MypageRepository mypageRepository;
     private final MemberRepository memberRepository;
+
     private final ModelMapper modelMapper = ModelMapping.getInstance();
 
     // JPQL로 조회한 결과 ProductResponseDto로 변환해서 전달
     private ProductResponseDto arrayToProductResponseDto(Object[] array) {
-        return new ProductResponseDto(
-                (String) array[0],
-                (String) array[1],
-                (Integer) array[2],
-                (Short) array[3],
-                (Integer) array[4],
-                (Branch) array[5],
-                (LocalDateTime) array[6]
-        );
+        return ProductResponseDto.builder()
+                .title((String) array[0])
+                .distance((Integer) array[1])
+                .branch((String) array[2])
+                .price((Integer) array[3])
+                .imageUrl((String) array[4])
+                .build();
     }
 
     // 등록한 매물 조회 (최신 등록 순)
@@ -56,11 +52,11 @@ public class MypageServiceImpl implements MypageService {
 
         return productsPage.map(this::arrayToProductResponseDto);
     }
-
-    // 구매 이력 조회 (최신 구매 순)
-    public Page<ProductResponseDto> getPurchaseProductsByMemberId(Long userId, int pageNumber, int pageSize){
+//
+//    // 구매 이력 조회 (최신 구매 순)
+    public Page<ProductResponseDto> getPurchaseProductsByMemberId(Long memberId, int pageNumber, int pageSize){
         Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("createdAt").descending());
-        Page<Object[]> productsPage = mypageRepository.getPurchaseProductsByMemberId(userId, pageable);
+        Page<Object[]> productsPage = mypageRepository.getPurchaseProductsByMemberId(memberId, pageable);
 
         return productsPage.map(this::arrayToProductResponseDto);
     }

--- a/backend/src/main/java/com/woochacha/backend/domain/product/entity/CarImage.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/entity/CarImage.java
@@ -1,5 +1,6 @@
 package com.woochacha.backend.domain.product.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicInsert;
@@ -21,6 +22,7 @@ public class CarImage {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
+    @JsonIgnore
     private Product product;
 
     @NotNull

--- a/backend/src/main/java/com/woochacha/backend/domain/product/entity/CarImage.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/entity/CarImage.java
@@ -22,7 +22,6 @@ public class CarImage {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
-    @JsonIgnore
     private Product product;
 
     @NotNull

--- a/backend/src/main/java/com/woochacha/backend/domain/product/entity/Product.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/entity/Product.java
@@ -50,6 +50,5 @@ public class Product {
     private CarDetail carDetail;
 
     @OneToMany(mappedBy = "product") // Transaction 엔티티와의 양방향 관계 설정
-    @JsonIgnore
     private List<CarImage> transactionList = new ArrayList<>();
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/transaction/entity/Transaction.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/transaction/entity/Transaction.java
@@ -20,11 +20,11 @@ public class Transaction {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "seller_id")
+    @JoinColumn(name = "sale_id")
     private SaleForm saleForm;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "buyer_id")
+    @JoinColumn(name = "purchase_id")
     private PurchaseForm purchaseForm;
 
     @CreationTimestamp


### PR DESCRIPTION
## 구현 기능
기존 : 구매이력, 판매이력, 등록매물 게시글 제목 -> carName 으로만 데이터 전달
수정 : model + " " + car_name + " " + year + "년형" 로 수정

## 관련 이슈

- Close #70 

## 세부 작업 내용

- [x] 구매이력 ProductResponseDto 수정
- [x] repository JPQL문 수정
- [x] postman 테스트
- [x] Transaction Entity의 DB 매핑 칼럼명 변경

## 참고 사항
[수정 전]
![image](https://github.com/woorifisa-projects/woochacha/assets/61819350/1c953ed3-5e8d-460d-8365-5936b993ce52)


[수정 후]
<img width="741" alt="image" src="https://github.com/woorifisa-projects/woochacha/assets/61819350/91a7644b-1e3c-445f-85c5-62273437836e">

