### PR TITLE
[design] 구매페이지 UI 레이아웃 구성

### DIFF
--- a/frontend/src/components/common/MiniCard.js
+++ b/frontend/src/components/common/MiniCard.js
@@ -1,7 +1,7 @@
 import { Card } from '@mui/material';
 import React from 'react';
 
-export default function MiniCard({ children, colorVal, shadowVal }) {
+export default function MiniCard({ children, colorVal, shadowVal, marginVal }) {
   return (
     <Card
       sx={{
@@ -10,9 +10,9 @@ export default function MiniCard({ children, colorVal, shadowVal }) {
         boxShadow: shadowVal,
         py: 8,
         px: 8,
-        my: 25,
+        my: marginVal,
         height: '100%',
-        width: '100%',
+        width: '80%',
         display: 'flex',
         flexDirection: 'column',
       }}>

--- a/frontend/src/components/product/FilterSideBar.js
+++ b/frontend/src/components/product/FilterSideBar.js
@@ -1,0 +1,152 @@
+import { useEffect, useState } from 'react';
+import {
+  Container,
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Typography,
+  Box,
+  FormGroup,
+  FormControlLabel,
+  Checkbox,
+  Button,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+
+export default function FilterSideBar() {
+  const [mounted, setMounted] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  // data 불러온 이후 필터링 data에 맞게 렌더링
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const handleChange = (panel) => (event, isExpanded) => {
+    setExpanded(isExpanded ? panel : false);
+  };
+
+  // TODO: API 통신 이후, 수정할 data입니다.
+  const dummySelectData = [
+    {
+      accordionId: 1,
+      accordionPanel: 'panel1',
+      typeTitle: '차종',
+      selectItems: [
+        {
+          id: 1,
+          carType: '경차',
+        },
+        {
+          id: 2,
+          carType: '소형',
+        },
+        {
+          id: 3,
+          carType: '준중형',
+        },
+      ],
+    },
+    {
+      accordionId: 2,
+      accordionPanel: 'panel2',
+      typeTitle: '색상',
+      selectItems: [
+        {
+          id: 1,
+          carType: '빨강',
+        },
+        {
+          id: 2,
+          carType: '주황',
+        },
+        {
+          id: 3,
+          carType: '노랑',
+        },
+      ],
+    },
+    {
+      accordionId: 3,
+      accordionPanel: 'panel3',
+      typeTitle: '차고지',
+      selectItems: [
+        {
+          id: 1,
+          carType: '경차',
+        },
+        {
+          id: 2,
+          carType: '소형',
+        },
+        {
+          id: 3,
+          carType: '준중형',
+        },
+      ],
+    },
+  ];
+
+  const filteringCss = {
+    container: {
+      backgroundColor: '#FFF',
+      width: '20%',
+      minWidth: '200px',
+      height: '80%',
+      boxShadow: 3,
+      padding: 3,
+      borderRadius: '1rem',
+    },
+    accordionTitle: {
+      width: '50%',
+      flexShrink: 1,
+    },
+    filteringBtn: {
+      fontSize: '1.1rem',
+      my: 5,
+    },
+  };
+
+  return (
+    mounted && (
+      <Container sx={filteringCss.container}>
+        <Typography variant="h5" component="h5" mb={5}>
+          필터링
+        </Typography>
+        <Box>
+          {dummySelectData.map((selectItem) => {
+            return (
+              <Accordion
+                key={selectItem.accordionId}
+                expanded={expanded === selectItem.accordionPanel}
+                onChange={handleChange(selectItem.accordionPanel)}>
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography sx={filteringCss.accordionTitle}>{selectItem.typeTitle}</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Typography>
+                    {/* select box 모음 */}
+                    <FormGroup>
+                      {selectItem.selectItems.map((item) => {
+                        return (
+                          <FormControlLabel
+                            key={item.id}
+                            control={<Checkbox value={item.id} />}
+                            label={item.carType}
+                          />
+                        );
+                      })}
+                    </FormGroup>
+                  </Typography>
+                </AccordionDetails>
+              </Accordion>
+            );
+          })}
+        </Box>
+        <Button variant="contained" fullWidth sx={filteringCss.filteringBtn}>
+          보러가기
+        </Button>
+      </Container>
+    )
+  );
+}

--- a/frontend/src/components/product/ProductCard.js
+++ b/frontend/src/components/product/ProductCard.js
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+import {
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  CardMedia,
+  Chip,
+  Grid,
+  Typography,
+} from '@mui/material';
+import { useRouter } from 'next/router';
+
+export default function ProductCard({ cardItems }) {
+  const router = useRouter();
+  const [mounted, setMounted] = useState(false);
+  const productCardCss = {
+    card: {
+      height: '100%',
+      display: 'flex',
+      flexDirection: 'column',
+      '&:hover': {
+        boxShadow: 10,
+        cursor: 'pointer',
+        transition: '0.3s',
+        transform: 'scale(1.03)',
+      },
+    },
+    cardMedia: { pt: '100%' },
+    cardContent: { flexGrow: 1 },
+  };
+
+  // data 불러온 이후 필터링 data에 맞게 렌더링
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const handleMoveDetail = (url) => {
+    router.push(url);
+  };
+
+  return (
+    mounted && (
+      <Grid container spacing={3}>
+        {cardItems.map((item) => (
+          <Grid item key={item.id} xs={12} sm={6} md={3}>
+            <Card sx={productCardCss.card} onClick={() => handleMoveDetail(item.productUrl)}>
+              <CardMedia component="div" sx={productCardCss.cardMedia} image={item.productImgUrl} />
+              <CardContent sx={productCardCss.cardContent}>
+                <Typography gutterBottom variant="h5" component="h5">
+                  {item.carName}
+                </Typography>
+                <Grid container my={1} gap={1}>
+                  <Chip variant="outlined" label={`${item.price} 만원`} />
+                  <Chip variant="outlined" label={`${item.createdDate}`} />
+                  <Chip variant="outlined" label={`${item.distance} km`} />
+                  <Chip variant="outlined" label={`${item.carWhere} 차고지`} />
+                </Grid>
+              </CardContent>
+              <CardActions>
+                <Button size="small">보러가기</Button>
+              </CardActions>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    )
+  );
+}

--- a/frontend/src/constants/string.js
+++ b/frontend/src/constants/string.js
@@ -80,6 +80,7 @@ export const CAPITAL_CONTENTS = [
   {
     miniCardColor: '#DEF2FF',
     miniCardShadow: 0,
+    miniCardMarginY: 25,
     capitalTitle: '리스/렌트 견적 비교',
     capitalImgUrl:
       'https://s7d1.scene7.com/is/image/hyundai/2023-ioniq-6-limited-rwd-transmission-blue-pearl-profile:Vehicle-Carousel?fmt=webp-alpha',
@@ -90,6 +91,7 @@ export const CAPITAL_CONTENTS = [
   {
     miniCardColor: '#EFFBFF',
     miniCardShadow: 0,
+    miniCardMarginY: 25,
     capitalTitle: '나의 대출한도 확인하기',
     capitalImgUrl: 'https://www.wooriwoncar.com/webassets/img/pc/main-loan-img1.png',
     capitalSubTitle: '나의 대출한도를 \n 확인하고 싶다면?',
@@ -100,6 +102,7 @@ export const CAPITAL_CONTENTS = [
   {
     miniCardColor: '#FFF',
     miniCardShadow: 0,
+    miniCardMarginY: 25,
     capitalTitle: '중고차 금융상품',
     capitalImgUrl: 'https://www.wooriwoncar.com/webassets/img/pc/sd-visual-new-bg.png',
     capitalSubTitle: '중고차 금융상품이 궁금하다면?',

--- a/frontend/src/pages/capitals/index.js
+++ b/frontend/src/pages/capitals/index.js
@@ -34,7 +34,10 @@ export default function Capitals() {
         {CAPITAL_CONTENTS.map((item) => {
           return (
             <>
-              <MiniCard colorVal={item.miniCardColor} shadowVal={item.miniCardShadow}>
+              <MiniCard
+                colorVal={item.miniCardColor}
+                shadowVal={item.miniCardShadow}
+                marginVal={item.miniCardMarginY}>
                 <Typography
                   mb={10}
                   component="h4"

--- a/frontend/src/pages/products/detail/[productId].js
+++ b/frontend/src/pages/products/detail/[productId].js
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react';
+import { CssBaseline, ThemeProvider, responsiveFontSizes } from '@mui/material';
+import theme from '@/styles/theme';
+import MiniCard from '@/components/common/MiniCard';
+import { useRouter } from 'next/router';
+
+export default function ProductDetail() {
+  const router = useRouter();
+  const { productId } = router.query;
+  let responsiveFontTheme = responsiveFontSizes(theme);
+  const [mounted, setMounted] = useState(false);
+
+  // TODO: API 호출 후, dummy data 수정 예정
+  const dummyDetailData = {
+    productBasicInfo: {
+      title: '기아 올 뉴 카니발 2018년형',
+      carNum: '22나2222',
+      branch: '서울',
+      price: 2690,
+    },
+    productDetailInfo: {
+      capacity: 9,
+      distance: 110000,
+      carType: 'RV',
+      fuelName: '디젤',
+      transmissionName: '오토',
+      produdctAccidentInfoList: [
+        {
+          type: '침수사고',
+          count: 1,
+        },
+        {
+          type: '교통사고',
+          count: 2,
+        },
+      ],
+      productExchangeInfoList: [
+        {
+          type: '본네트',
+          count: 1,
+        },
+        {
+          type: '뒷문',
+          count: 1,
+        },
+      ],
+    },
+    productOptionInfo: [
+      {
+        option: '열선시트',
+        whether: 1,
+      },
+      {
+        option: '스마트키',
+        whether: 0,
+      },
+      {
+        option: '블랙박스',
+        whether: 1,
+      },
+      {
+        option: '네비게이션',
+        whether: 0,
+      },
+      {
+        option: '에어백',
+        whether: 1,
+      },
+      {
+        option: '썬루프',
+        whether: 1,
+      },
+      {
+        option: '하이패스',
+        whether: 0,
+      },
+      {
+        option: '후방카메라',
+        whether: 1,
+      },
+    ],
+    productOwnerInfo: null,
+    carImageList: null,
+  };
+
+  // data 불러온 이후 필터링 data에 맞게 렌더링
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return (
+    mounted && (
+      <ThemeProvider theme={responsiveFontTheme}>
+        <CssBaseline />
+        {/* main page */}
+        <main>
+          {/* 차량 디테일 페이지 */}
+          <MiniCard colorVal="#def2ff" shadowVal={3} marginVal={10}>
+            차량 {productId}의 디테일 페이지
+          </MiniCard>
+        </main>
+      </ThemeProvider>
+    )
+  );
+}

--- a/frontend/src/pages/products/index.js
+++ b/frontend/src/pages/products/index.js
@@ -1,5 +1,165 @@
-import React from 'react';
+import {
+  Container,
+  CssBaseline,
+  Grid,
+  Pagination,
+  ThemeProvider,
+  Typography,
+  responsiveFontSizes,
+} from '@mui/material';
+import theme from '@/styles/theme';
+import MiniCard from '@/components/common/MiniCard';
+import SearchBar from '@/components/product/SearchBar';
+import ProductCard from '@/components/product/ProductCard';
+import FilterSideBar from '@/components/product/FilterSideBar';
+import { useEffect, useState } from 'react';
 
 export default function Products() {
-  return <div>전체 상품 조회 페이지</div>;
+  const [mounted, setMounted] = useState(false);
+  let responsiveFontTheme = responsiveFontSizes(theme);
+
+  // TODO: API 조회 후 수정할 dummy data입니다.
+  const itemDummyArr = [
+    {
+      productImgUrl: 'https://source.unsplash.com/random?car',
+      carName: '멋쟁이 자동차1',
+      price: '300',
+      createdDate: '2023-07',
+      distance: '58,972',
+      carWhere: '인천',
+      productUrl: '/products/detail/1',
+    },
+    {
+      productImgUrl: 'https://source.unsplash.com/random?bmw',
+      carName: '멋쟁이 자동차2',
+      price: '3000',
+      createdDate: '2023-05',
+      distance: '58,999',
+      carWhere: '대전',
+      productUrl: '/products/detail/2',
+    },
+    {
+      productImgUrl: 'https://source.unsplash.com/random?benz',
+      carName: '멋쟁이 자동차3',
+      price: '5000',
+      createdDate: '2023-02',
+      distance: '38,972',
+      carWhere: '부산',
+      productUrl: '/products/detail/3',
+    },
+    {
+      productImgUrl: 'https://source.unsplash.com/random?car',
+      carName: '멋쟁이 자동차4',
+      price: '300',
+      createdDate: '2023-07',
+      distance: '58,972',
+      carWhere: '인천',
+      productUrl: '/products/detail/4',
+    },
+    {
+      productImgUrl: 'https://source.unsplash.com/random?bmw',
+      carName: '멋쟁이 자동차5',
+      price: '3000',
+      createdDate: '2023-05',
+      distance: '58,999',
+      carWhere: '대전',
+      productUrl: '/products/detail/5',
+    },
+    {
+      productImgUrl: 'https://source.unsplash.com/random?benz',
+      carName: '멋쟁이 자동차6',
+      price: '5000',
+      createdDate: '2023-02',
+      distance: '38,972',
+      carWhere: '부산',
+      productUrl: '/products/detail/6',
+    },
+    {
+      productImgUrl: 'https://source.unsplash.com/random?car',
+      carName: '멋쟁이 자동차7',
+      price: '300',
+      createdDate: '2023-07',
+      distance: '58,972',
+      carWhere: '인천',
+      productUrl: '/products/detail/7',
+    },
+    {
+      productImgUrl: 'https://source.unsplash.com/random?bmw',
+      carName: '멋쟁이 자동차8',
+      price: '3000',
+      createdDate: '2023-05',
+      distance: '58,999',
+      carWhere: '대전',
+      productUrl: '/products/detail/8',
+    },
+    {
+      productImgUrl: 'https://source.unsplash.com/random?benz',
+      carName: '멋쟁이 자동차9',
+      price: '5000',
+      createdDate: '2023-02',
+      distance: '38,972',
+      carWhere: '부산',
+      productUrl: '/products/detail/9',
+    },
+    {
+      productImgUrl: 'https://source.unsplash.com/random?benz',
+      carName: '멋쟁이 자동차10',
+      price: '5000',
+      createdDate: '2023-02',
+      distance: '38,972',
+      carWhere: '부산',
+      productUrl: '/products/detail/10',
+    },
+  ];
+
+  // data 불러온 이후 필터링 data에 맞게 렌더링
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const productsCss = {
+    gridContent: {
+      height: '100%',
+      display: 'flex',
+      flexDirection: 'row',
+    },
+    contentContainer: {
+      py: 3,
+    },
+    pagination: { display: 'flex', justifyContent: 'center', my: 8 },
+  };
+
+  return (
+    mounted && (
+      <ThemeProvider theme={responsiveFontTheme}>
+        <CssBaseline />
+        {/* main page */}
+        <main>
+          {/* 페이지 상단 serch box */}
+          <MiniCard colorVal="#def2ff" shadowVal={3} marginVal={10}>
+            <Typography gutterBottom variant="h5" component="h5" mb={3}>
+              궁금한 차량 조회하기
+            </Typography>
+            <SearchBar />
+          </MiniCard>
+
+          {/* 메인 페이지 content */}
+          <Grid sx={productsCss.gridContent}>
+            {/* 구매 페이지 filltering side bar */}
+            <FilterSideBar />
+
+            {/* 차량게시글 관련 content */}
+            <Container sx={productsCss.contentContainer} maxWidth="md">
+              <ProductCard cardItems={itemDummyArr} />
+            </Container>
+          </Grid>
+
+          {/* pagination */}
+          <Grid sx={productsCss.pagination}>
+            <Pagination count={10} />
+          </Grid>
+        </main>
+      </ThemeProvider>
+    )
+  );
 }


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- 구매 페이지의 전체적인 레이아웃을 구성

## 관련 이슈

- Close #67 

## 세부 작업 내용

- [x] 구매 필터링 사이드바 구현
- [x] 구매 검색창 구현
- [x] 구매 전체적인 레이아웃 구현

## 참고 사항

- TODO로 표기해둔 dummy data들은 추후 API로 데이터를 받으면 수정할 계획입니다.
- 구매페이지
![products-page01](https://github.com/woorifisa-projects/woochacha/assets/81960250/a8bab5aa-188b-4e78-bae4-3acaff5b970b)



