### PR TITLE
[Chore] 회원가입 시 기본 프로필 이미지 설정&로그인 응답에 이름, 아이디 추가&로그인 응답 헤더에 토큰 추가

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/controller/MemberController.java
@@ -1,10 +1,14 @@
 package com.woochacha.backend.domain.member.controller;
 
+import com.woochacha.backend.domain.jwt.JwtFilter;
 import com.woochacha.backend.domain.member.dto.LoginRequestDto;
 import com.woochacha.backend.domain.member.dto.LoginResponseDto;
 import com.woochacha.backend.domain.member.dto.SignUpRequestDto;
 import com.woochacha.backend.domain.member.dto.SignUpResponseDto;
 import com.woochacha.backend.domain.member.service.SignService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -30,8 +34,13 @@ public class MemberController {
     }
 
     @PostMapping("/login")
-    public LoginResponseDto login(@RequestBody LoginRequestDto loginRequestDto) {
-        return signService.login(loginRequestDto);
+    public ResponseEntity<LoginResponseDto> login(@RequestBody LoginRequestDto loginRequestDto) {
+        LoginResponseDto loginResponseDto = signService.login(loginRequestDto);
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add(JwtFilter.AUTHORIZATION_HEADER, loginResponseDto.getToken());
+        return ResponseEntity.ok()
+                .headers(httpHeaders)
+                .body(loginResponseDto);
     }
 
     @PostMapping("/logout")

--- a/backend/src/main/java/com/woochacha/backend/domain/member/dto/LoginResponseDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/dto/LoginResponseDto.java
@@ -12,4 +12,5 @@ public class LoginResponseDto {
     private int code;
     private String msg;
     private String token;
+    private String name;
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/member/dto/LoginResponseDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/dto/LoginResponseDto.java
@@ -2,8 +2,6 @@ package com.woochacha.backend.domain.member.dto;
 
 import lombok.*;
 
-//@Data
-@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @Getter
@@ -12,5 +10,11 @@ public class LoginResponseDto {
     private int code;
     private String msg;
     private String token;
+    private Long id;
     private String name;
+
+    public LoginResponseDto(int code, String msg) {
+        this.code = code;
+        this.msg = msg;
+    }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/member/dto/SignUpRequestDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/dto/SignUpRequestDto.java
@@ -10,4 +10,5 @@ public class SignUpRequestDto {
     private String password;
     private String name;
     private String phone;
+    private String profileImage;
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/entity/Member.java
@@ -30,7 +30,7 @@ public class Member implements UserDetails {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ColumnDefault("1")
+    @ColumnDefault("0")
     private Byte role;
 
     @NotNull
@@ -57,6 +57,7 @@ public class Member implements UserDetails {
     @ColumnDefault("1")
     private Byte status;
 
+    @NotNull
     private String profileImage;
 
 

--- a/backend/src/main/java/com/woochacha/backend/domain/member/exception/LoginException.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/exception/LoginException.java
@@ -7,19 +7,19 @@ import org.springframework.security.core.AuthenticationException;
 public class LoginException {
     public static LoginResponseDto exception(Exception e) {
         if (e instanceof BadCredentialsException) {
-            return new LoginResponseDto(2, "없는 아이디 또는 비밀번호", null, null);
+            return new LoginResponseDto(2, "없는 아이디 또는 비밀번호");
         } else if (e instanceof DisabledException) {
-            return new LoginResponseDto(3, "사용 불가 계정", null, null);
+            return new LoginResponseDto(3, "사용 불가 계정");
         } else if (e instanceof LockedException) {
-            return new LoginResponseDto(4, "잠긴 계정", null, null);
+            return new LoginResponseDto(4, "잠긴 계정");
         } else if (e instanceof AccountExpiredException) {
-            return new LoginResponseDto(5, "만료된 계정", null, null);
+            return new LoginResponseDto(5, "만료된 계정");
         } else if (e instanceof CredentialsExpiredException) {
-            return new LoginResponseDto(6, "비밀번호가 만료된 계정", null, null);
+            return new LoginResponseDto(6, "비밀번호가 만료된 계정");
         } else if (e instanceof AuthenticationException) {
-            return new LoginResponseDto(7, "시스템 에러", null, null);
+            return new LoginResponseDto(7, "시스템 에러");
         } else {
-            return new LoginResponseDto(8, "찾을 수 없는 계정", null, null);
+            return new LoginResponseDto(8, "찾을 수 없는 계정");
         }
     }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/member/exception/LoginException.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/exception/LoginException.java
@@ -7,19 +7,19 @@ import org.springframework.security.core.AuthenticationException;
 public class LoginException {
     public static LoginResponseDto exception(Exception e) {
         if (e instanceof BadCredentialsException) {
-            return new LoginResponseDto(2, "없는 아이디 또는 비밀번호", null);
+            return new LoginResponseDto(2, "없는 아이디 또는 비밀번호", null, null);
         } else if (e instanceof DisabledException) {
-            return new LoginResponseDto(3, "사용 불가 계정", null);
+            return new LoginResponseDto(3, "사용 불가 계정", null, null);
         } else if (e instanceof LockedException) {
-            return new LoginResponseDto(4, "잠긴 계정", null);
+            return new LoginResponseDto(4, "잠긴 계정", null, null);
         } else if (e instanceof AccountExpiredException) {
-            return new LoginResponseDto(5, "만료된 계정", null);
+            return new LoginResponseDto(5, "만료된 계정", null, null);
         } else if (e instanceof CredentialsExpiredException) {
-            return new LoginResponseDto(6, "비밀번호가 만료된 계정", null);
+            return new LoginResponseDto(6, "비밀번호가 만료된 계정", null, null);
         } else if (e instanceof AuthenticationException) {
-            return new LoginResponseDto(7, "시스템 에러", null);
+            return new LoginResponseDto(7, "시스템 에러", null, null);
         } else {
-            return new LoginResponseDto(8, "찾을 수 없는 계정", null);
+            return new LoginResponseDto(8, "찾을 수 없는 계정", null, null);
         }
     }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/repository/MemberRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findByEmail(String email);
+    Optional<Member> findMemberByEmail(String email);
 
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/member/service/SignService.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/service/SignService.java
@@ -4,6 +4,7 @@ import com.woochacha.backend.domain.member.dto.LoginRequestDto;
 import com.woochacha.backend.domain.member.dto.LoginResponseDto;
 import com.woochacha.backend.domain.member.dto.SignUpRequestDto;
 import com.woochacha.backend.domain.member.dto.SignUpResponseDto;
+import org.springframework.http.ResponseEntity;
 
 public interface SignService {
     SignUpResponseDto signUp(SignUpRequestDto userRequestDto);

--- a/backend/src/main/java/com/woochacha/backend/domain/member/service/impl/SignServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/service/impl/SignServiceImpl.java
@@ -37,7 +37,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Service
-//@Transactional
+@Transactional(readOnly = true)
 public class SignServiceImpl implements SignService {
 
     private final JPAQueryFactory queryFactory;
@@ -67,6 +67,7 @@ public class SignServiceImpl implements SignService {
         [회원가입]
         @Params : signUpRequestDto - email, name, phone, password
      */
+    @Transactional
     public SignUpResponseDto signUp(SignUpRequestDto signUpRequestDto) {
 
         SignUpResponseDto signUpResponseDto = new SignUpResponseDto();
@@ -105,7 +106,7 @@ public class SignServiceImpl implements SignService {
         return signUpResponseDto;
     }
 
-//    @Transactional
+    @Transactional
     public LoginResponseDto login(LoginRequestDto loginRequestDto) throws BadCredentialsException {
         try {
             Member member = memberRepository.findMemberByEmail(loginRequestDto.getEmail())
@@ -124,7 +125,7 @@ public class SignServiceImpl implements SignService {
             // Authentication 객체를 createToken 메소드를 통해서 JWT Token을 생성
             String jwt = jwtTokenProvider.createToken(authentication);
 
-            return new LoginResponseDto(1, "성공", jwt, member.getName());
+            return new LoginResponseDto(1, "성공", jwt, member.getId(), member.getName());
         } catch (Exception e) {
             return LoginException.exception(e);
         }
@@ -137,7 +138,6 @@ public class SignServiceImpl implements SignService {
 
 
     public Member save(SignUpRequestDto signUpRequestDto) {
-
         LOGGER.info(modelMapper.toString());
         signUpRequestDto.setPassword(passwordEncoder.encode(signUpRequestDto.getPassword()));
         Member savedMember = modelMapper.map(signUpRequestDto, Member.class);

--- a/backend/src/main/java/com/woochacha/backend/domain/member/service/impl/UserDetailsServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/service/impl/UserDetailsServiceImpl.java
@@ -1,5 +1,6 @@
 package com.woochacha.backend.domain.member.service.impl;
 
+import com.woochacha.backend.domain.member.entity.Member;
 import com.woochacha.backend.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,21 +8,22 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 // 인증에 필요한 UserDetailsService interface의 loadUserByUsername 메서드를 구현하는 클래스로
 // loadUserByUsername 메서드를 통해 Database에 접근하여 사용자 정보를 가지고 온다.
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class UserDetailsServiceImpl implements UserDetailsService {
     @Autowired
     private final MemberRepository memberRepository;
 
-    // 유효한 사용자일 경우
+    // 유효한 사용자인지 확인
     @Override
     public UserDetails loadUserByUsername(String email)
             throws UsernameNotFoundException {
-        return (UserDetails) memberRepository.findByEmail(email)
+        return memberRepository.findMemberByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
     }
-
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/member/service/impl/UserDetailsServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/service/impl/UserDetailsServiceImpl.java
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional
 public class UserDetailsServiceImpl implements UserDetailsService {
-    @Autowired
+
     private final MemberRepository memberRepository;
 
     // 유효한 사용자인지 확인


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- 회원가입 시 프로필 이미지는 null로 db에 저장되던 것을 s3에 저장된 기본 프로필 이미지로 저장되도록 수정
- 로그인 시 프론트엔드에 전달할 member name 데이터 추가
- 로그인 시 ResponseHeader에 jwt 토큰 포함
- 회원가입 시 기본 권한 수정

## 관련 이슈

- Close #73

## 세부 작업 내용

- [x] 회원가입 시 프로필 이미지는 null로 db에 저장되던 것을 s3에 저장된 default 이미지로 저장되도록 수정
- [x] 로그인 시 프론트엔드 응답 바디에 member name, id 데이터 추가
- [x] 로그인 시 응답 헤더에 jwt 토큰 포함
- [x] SignServiceImpl.java 파일에 @Transcational 추가
- [x] Member entity의 role 기본값을 0으로 수정. (1:관리자), (0:일반 사용자)
<br>

## 참고 사항
- 회원가입 시 프로필 이미지 데이터가 아래와같이 추가되었습니다.
![image](https://github.com/woorifisa-projects/woochacha/assets/93786956/f5e11e2d-dc5e-48b6-878b-56130aa21e4d)
<br>

- 로그인 성공 시 아래와 같은 데이터를 전달합니다.
[body]
![image](https://github.com/woorifisa-projects/woochacha/assets/93786956/30159dc1-c7ee-491f-9604-0529b3923630)

[header]
![image](https://github.com/woorifisa-projects/woochacha/assets/93786956/652ffc3a-b230-4e5d-9bb2-aa255db4497b)
<br>

- 로그인 실패 시 아래와 같이 전달합니다.
![image](https://github.com/woorifisa-projects/woochacha/assets/93786956/5a0611f0-5e9e-48bf-b17c-b33370cd9ed1)

