### PR TITLE
[Feat] 백엔드 판매 요청폼 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/controller/MypageController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/controller/MypageController.java
@@ -2,6 +2,7 @@ package com.woochacha.backend.domain.mypage.controller;
 
 import com.woochacha.backend.domain.mypage.dto.ProductResponseDto;
 import com.woochacha.backend.domain.mypage.dto.ProfileDto;
+import com.woochacha.backend.domain.mypage.dto.SaleFormDto;
 import com.woochacha.backend.domain.mypage.service.impl.MypageServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -58,5 +59,14 @@ public class MypageController {
     private ResponseEntity<ProfileDto> mypage(@PathVariable Long memberId){
         ProfileDto profileDto = mypageService.getProfileByMemberId(memberId);
         return ResponseEntity.ok(profileDto);
+    }
+
+    // 마이페이지 판매 신청폼 조회
+    @GetMapping("/sale-request/{memberId}")
+    public ResponseEntity<Page<SaleFormDto>> retrievePosts(@PathVariable Long memberId,
+                                                           @RequestParam(defaultValue = "0") int page,
+                                                           @RequestParam(defaultValue = "5") int size) {
+        Page<SaleFormDto> saleFormsPage = mypageService.getSaleFormsByMemberId(memberId, page, size);
+        return ResponseEntity.ok(saleFormsPage);
     }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/EditProductDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/EditProductDto.java
@@ -1,0 +1,19 @@
+package com.woochacha.backend.domain.mypage.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class EditProductDto {
+
+    private String title;
+    private String image;
+    private Integer price;
+
+    public EditProductDto(String title, String image, Integer price) {
+        this.title = title;
+        this.image = image;
+        this.price = price;
+    }
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/SaleFormDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/SaleFormDto.java
@@ -1,0 +1,30 @@
+package com.woochacha.backend.domain.mypage.dto;
+
+import com.woochacha.backend.domain.member.entity.Member;
+import com.woochacha.backend.domain.sale.entity.Branch;
+import com.woochacha.backend.domain.status.entity.CarStatus;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+public class SaleFormDto {
+
+    private String carNum; // 차량 번호
+    private LocalDateTime createdAt; // 신청폼 작성일
+    private Branch branch; // 신청폼 작성시 선택한 차고지
+    private CarStatus carStatus; // 신청폼 상태 (반려, 심사중, 심사완료)
+
+    public SaleFormDto(String carNum, LocalDateTime createdAt, Branch branch, CarStatus carStatus) {
+        this.carNum = carNum;
+        this.createdAt = createdAt;
+        this.branch = branch;
+        this.carStatus = carStatus;
+    }
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/SaleFormDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/SaleFormDto.java
@@ -1,11 +1,8 @@
 package com.woochacha.backend.domain.mypage.dto;
 
-import com.woochacha.backend.domain.sale.entity.Branch;
-import com.woochacha.backend.domain.status.entity.CarStatus;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
 import java.time.LocalDateTime;
 
 @Data

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/SaleFormDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/SaleFormDto.java
@@ -1,27 +1,24 @@
 package com.woochacha.backend.domain.mypage.dto;
 
-import com.woochacha.backend.domain.member.entity.Member;
 import com.woochacha.backend.domain.sale.entity.Branch;
 import com.woochacha.backend.domain.status.entity.CarStatus;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
-import javax.persistence.*;
-import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 @Data
 @NoArgsConstructor
+@Builder
 public class SaleFormDto {
 
     private String carNum; // 차량 번호
     private LocalDateTime createdAt; // 신청폼 작성일
-    private Branch branch; // 신청폼 작성시 선택한 차고지
-    private CarStatus carStatus; // 신청폼 상태 (반려, 심사중, 심사완료)
+    private String branch; // 신청폼 작성시 선택한 차고지
+    private String carStatus; // 신청폼 상태 (반려, 심사중, 심사완료)
 
-    public SaleFormDto(String carNum, LocalDateTime createdAt, Branch branch, CarStatus carStatus) {
+    public SaleFormDto(String carNum, LocalDateTime createdAt, String branch, String carStatus) {
         this.carNum = carNum;
         this.createdAt = createdAt;
         this.branch = branch;

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/repository/MypageRepository.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/repository/MypageRepository.java
@@ -63,6 +63,13 @@ public interface MypageRepository extends JpaRepository<SaleForm, Long> {
             "AND ci.imageUrl LIKE '%/1' " +
             "ORDER BY tr.createdAt ASC ")
     Page<Object[]> getPurchaseProductsByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+
+    // 판매 신청폼 조회
+    @Query("SELECT sf.carNum, sf.createdAt, CAST(sf.branch.name AS string), CAST(sf.carStatus.status AS string) " +
+            "FROM SaleForm AS sf " +
+            "WHERE sf.member.id = :memberId " +
+            "ORDER BY sf.createdAt ASC ")
+    Page<Object[]> findAllByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 }
 
 

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
@@ -8,8 +8,8 @@ import com.woochacha.backend.domain.mypage.dto.ProfileDto;
 import com.woochacha.backend.domain.mypage.dto.SaleFormDto;
 import com.woochacha.backend.domain.mypage.repository.MypageRepository;
 import com.woochacha.backend.domain.mypage.service.MypageService;
-import com.woochacha.backend.domain.sale.entity.SaleForm;
-import com.woochacha.backend.domain.sale.repository.SaleFormRepository;
+import com.woochacha.backend.domain.sale.entity.Branch;
+import com.woochacha.backend.domain.status.entity.CarStatus;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Page;
@@ -19,8 +19,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import java.time.LocalDateTime;
 
 @Service
 @Transactional(readOnly = true)
@@ -29,7 +28,6 @@ public class MypageServiceImpl implements MypageService {
 
     private final MypageRepository mypageRepository;
     private final MemberRepository memberRepository;
-    private final SaleFormRepository saleFormRepository;
     private final ModelMapper modelMapper = ModelMapping.getInstance();
 
     // JPQL로 조회한 결과 ProductResponseDto로 변환해서 전달
@@ -40,6 +38,16 @@ public class MypageServiceImpl implements MypageService {
                 .branch((String) array[2])
                 .price((Integer) array[3])
                 .imageUrl((String) array[4])
+                .build();
+    }
+
+    // JPQL로 조회한 결과 SaleFormDto로 변환해서 전달
+    private SaleFormDto arrayToSaleFormDto(Object[] array) {
+        return SaleFormDto.builder()
+                .carNum((String) array[0])
+                .createdAt((LocalDateTime) array[1])
+                .branch((String) array[2])
+                .carStatus((String) array[3])
                 .build();
     }
 
@@ -76,9 +84,8 @@ public class MypageServiceImpl implements MypageService {
     // 판매 요청 폼 조회
     public Page<SaleFormDto> getSaleFormsByMemberId(Long memberId, int pageNumber, int pageSize){
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
-        Page<SaleForm> saleFormsPage = saleFormRepository.findAllById(memberId, pageable);
-        // SaleForm 엔티티를 SaleFormDto로 매핑
-        Page<SaleFormDto> saleFormDtosPage = saleFormsPage.map(saleForm -> modelMapper.map(saleForm, SaleFormDto.class));
+        Page<Object[]> saleFormsPage = mypageRepository.findAllByMemberId(memberId, pageable);
+        Page<SaleFormDto> saleFormDtosPage = saleFormsPage.map(this::arrayToSaleFormDto);
         return saleFormDtosPage;
     }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
@@ -5,8 +5,11 @@ import com.woochacha.backend.domain.member.entity.Member;
 import com.woochacha.backend.domain.member.repository.MemberRepository;
 import com.woochacha.backend.domain.mypage.dto.ProductResponseDto;
 import com.woochacha.backend.domain.mypage.dto.ProfileDto;
+import com.woochacha.backend.domain.mypage.dto.SaleFormDto;
 import com.woochacha.backend.domain.mypage.repository.MypageRepository;
 import com.woochacha.backend.domain.mypage.service.MypageService;
+import com.woochacha.backend.domain.sale.entity.SaleForm;
+import com.woochacha.backend.domain.sale.repository.SaleFormRepository;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Page;
@@ -16,6 +19,9 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -23,6 +29,7 @@ public class MypageServiceImpl implements MypageService {
 
     private final MypageRepository mypageRepository;
     private final MemberRepository memberRepository;
+    private final SaleFormRepository saleFormRepository;
     private final ModelMapper modelMapper = ModelMapping.getInstance();
 
     // JPQL로 조회한 결과 ProductResponseDto로 변환해서 전달
@@ -64,6 +71,15 @@ public class MypageServiceImpl implements MypageService {
     public ProfileDto getProfileByMemberId(Long userId) {
         Member member = memberRepository.findById(userId).orElseThrow(() -> new RuntimeException("Member not found"));
         return modelMapper.map(member, ProfileDto.class);
+    }
+
+    // 판매 요청 폼 조회
+    public Page<SaleFormDto> getSaleFormsByMemberId(Long memberId, int pageNumber, int pageSize){
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        Page<SaleForm> saleFormsPage = saleFormRepository.findAllById(memberId, pageable);
+        // SaleForm 엔티티를 SaleFormDto로 매핑
+        Page<SaleFormDto> saleFormDtosPage = saleFormsPage.map(saleForm -> modelMapper.map(saleForm, SaleFormDto.class));
+        return saleFormDtosPage;
     }
 }
 

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
@@ -81,7 +81,7 @@ public class MypageServiceImpl implements MypageService {
         return modelMapper.map(member, ProfileDto.class);
     }
 
-    // 판매 요청 폼 조회
+    // 판매 신청 폼 조회
     public Page<SaleFormDto> getSaleFormsByMemberId(Long memberId, int pageNumber, int pageSize){
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
         Page<Object[]> saleFormsPage = mypageRepository.findAllByMemberId(memberId, pageable);

--- a/backend/src/main/java/com/woochacha/backend/domain/sale/repository/README.md
+++ b/backend/src/main/java/com/woochacha/backend/domain/sale/repository/README.md
@@ -1,1 +1,0 @@
-folder setting

--- a/backend/src/main/java/com/woochacha/backend/domain/sale/repository/SaleFormRepository.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/sale/repository/SaleFormRepository.java
@@ -1,0 +1,12 @@
+package com.woochacha.backend.domain.sale.repository;
+
+import com.woochacha.backend.domain.sale.entity.SaleForm;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SaleFormRepository extends JpaRepository<SaleForm, Long> {
+    Page<SaleForm> findAllById(Long memberId, Pageable pageable);
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/sale/repository/SaleFormRepository.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/sale/repository/SaleFormRepository.java
@@ -1,12 +1,9 @@
 package com.woochacha.backend.domain.sale.repository;
 
 import com.woochacha.backend.domain.sale.entity.SaleForm;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SaleFormRepository extends JpaRepository<SaleForm, Long> {
-    Page<SaleForm> findAllById(Long memberId, Pageable pageable);
 }


### PR DESCRIPTION
## 구현 기능
- 마이페이지 판매 요청폼 리스트 조회 구현

## 관련 이슈

- Close #55 

## 세부 작업 내용

- [x] 판매 요청폼 조회 시 사용할 SaleFormDto 객체 생성
- [x] 판매 요청폼 조회하는 Service 함수 작성
- [x] /mypage/sale-request/{user_id} API 생성을 위한 MypageController의 GetMapping 작성
- [x] 주석 정리, 안쓰는 import문 정리

## 참고 사항

- 리뷰어에게 참고할만한 사항을 입력해주세요.

- 피그마의 디자인 상으론 판매 요청폼 조회 페이지에 "게시글로 이동", "게시글 제목", "차량 이미지" 등의 정보가 있지만
- 판매 요청 폼의 경우 아직 게시글이 등록되지 않은 상태도 포함하고, 게시글이 등록된 경우 따로 등록한 매물 조회 페이지에서 등록된 게시글을 확인할 수 있기 때문에 아래와 같은 데이터만 전달하는 방식으로 코드를 작성했습니다 !
- 판매요청폼을 작성할 때 "차량 번호", "차고지" 만 입력하기 때문에 1. 폼 심사여부 상태 2. 차량 번호  3. 차고지 4. 폼 작성일 데이터만 보여줘도 될 것 같습니다. -> 이 부분은 추가 의견 주시면 좋을 것 같습니다 ! 
- +) 소민언니 -> LocalDateTime으로 데이터를 전달할 때 시간까지 포함돼서 년월일만 포함해서 보내려고 했지만, 에러때문에 우선 LocalDateTime으로 두었습니다. 폼 작성일은 나타내지 않아도 괜찮을 것 같은데, 이 부분도 의견 주시면 좋을 것 같아요 !
- 페이지네이션) 이전과 동일하게 0페이지부터 시작, 한 페이지당 5개씩 보여주는 방식입니다 !
- 데이터는 신청폼 작성일 최신순으로 전달됩니다.

[프론트에 전달할 데이터]
<img width="384" alt="image" src="https://github.com/woorifisa-projects/woochacha/assets/61819350/1fad301a-53c1-4da5-b5b4-598e6e81e7ca">
