### PR TITLE
[Feat] 매물 전체 조회 시 필터링 목록 데이터, product id를 포함하여 전달

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/car/detail/dto/CarNameDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/detail/dto/CarNameDto.java
@@ -1,0 +1,9 @@
+package com.woochacha.backend.domain.car.detail.dto;
+
+import lombok.Data;
+
+@Data
+public class CarNameDto {
+    private Long id;
+    private String name;
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/car/detail/dto/README.md
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/detail/dto/README.md
@@ -1,1 +1,0 @@
-folder setting

--- a/backend/src/main/java/com/woochacha/backend/domain/car/type/dto/ColorDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/type/dto/ColorDto.java
@@ -1,0 +1,9 @@
+package com.woochacha.backend.domain.car.type.dto;
+
+import lombok.Data;
+
+@Data
+public class ColorDto {
+    private int id;
+    private String name;
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/car/type/dto/FuelDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/type/dto/FuelDto.java
@@ -1,0 +1,9 @@
+package com.woochacha.backend.domain.car.type.dto;
+
+import lombok.Data;
+
+@Data
+public class FuelDto {
+    private int id;
+    private String name;
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/car/type/dto/ModelDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/type/dto/ModelDto.java
@@ -1,0 +1,9 @@
+package com.woochacha.backend.domain.car.type.dto;
+
+import lombok.Data;
+
+@Data
+public class ModelDto {
+    private Integer id;
+    private String name;
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/car/type/dto/README.md
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/type/dto/README.md
@@ -1,1 +1,0 @@
-folder setting

--- a/backend/src/main/java/com/woochacha/backend/domain/car/type/dto/TrasmissionDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/type/dto/TrasmissionDto.java
@@ -1,0 +1,9 @@
+package com.woochacha.backend.domain.car.type.dto;
+
+import lombok.Data;
+
+@Data
+public class TrasmissionDto {
+    private int id;
+    private String name;
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/car/type/dto/TypeDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/type/dto/TypeDto.java
@@ -1,0 +1,9 @@
+package com.woochacha.backend.domain.car.type.dto;
+
+import lombok.Data;
+
+@Data
+public class TypeDto {
+    private int id;
+    private String name;
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/car/type/entity/TypeList.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/type/entity/TypeList.java
@@ -1,5 +1,5 @@
 package com.woochacha.backend.domain.car.type.entity;
 
 public enum TypeList {
-    경차, 소형, 준중형, 중형, 대형, 스포츠카, RV, SUV, 승합, 버스, 트럭, 특수, 중기
+    경차, 소형, 준중형, 대형, 스포츠카, RV, SUV, 승합, 버스, 트럭, 특수, 중기, 중형
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/product/controller/ProductController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/controller/ProductController.java
@@ -1,6 +1,6 @@
 package com.woochacha.backend.domain.product.controller;
 
-import com.woochacha.backend.domain.product.dto.ProdcutResponseDto;
+import com.woochacha.backend.domain.product.dto.ProdcutAllResponseDto;
 import com.woochacha.backend.domain.product.dto.ProductDetailResponseDto;
 import com.woochacha.backend.domain.product.service.ProductService;
 import org.springframework.web.bind.annotation.*;
@@ -18,7 +18,7 @@ public class ProductController {
     }
 
     @GetMapping
-    public List<ProdcutResponseDto> findAllProduct() {
+    public ProdcutAllResponseDto findAllProduct() {
         return productService.findAllProduct();
     }
 

--- a/backend/src/main/java/com/woochacha/backend/domain/product/dto/ProdcutAllResponseDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/dto/ProdcutAllResponseDto.java
@@ -1,0 +1,15 @@
+package com.woochacha.backend.domain.product.dto;
+
+import com.woochacha.backend.domain.product.dto.all.ProductFilterInfo;
+import com.woochacha.backend.domain.product.dto.all.ProductInfo;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class ProdcutAllResponseDto {
+    private List<ProductInfo> productInfo; // 매물 전체 정보
+    private ProductFilterInfo productFilterInfo; // 필터링 목록 정보
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/product/dto/all/ProductFilterInfo.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/dto/all/ProductFilterInfo.java
@@ -1,0 +1,26 @@
+package com.woochacha.backend.domain.product.dto.all;
+
+import com.querydsl.core.Tuple;
+import com.woochacha.backend.domain.car.detail.dto.CarNameDto;
+import com.woochacha.backend.domain.car.detail.entity.CarName;
+import com.woochacha.backend.domain.car.type.dto.*;
+import com.woochacha.backend.domain.car.type.entity.*;
+import com.woochacha.backend.domain.sale.dto.BranchDto;
+import com.woochacha.backend.domain.sale.entity.Branch;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class ProductFilterInfo {
+    List<TypeDto> typeList;
+    List<ModelDto> modelList;
+    List<CarNameDto> carNameList;
+    List<FuelDto> fuelList;
+    List<ColorDto> colorList;
+    List<TrasmissionDto> transmissionList;
+    List<BranchDto> branchList;
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/product/dto/all/ProductInfo.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/dto/all/ProductInfo.java
@@ -1,12 +1,11 @@
-package com.woochacha.backend.domain.product.dto;
+package com.woochacha.backend.domain.product.dto.all;
 
-import com.woochacha.backend.domain.sale.entity.Branch;
 import lombok.Data;
 
-import java.time.LocalDateTime;
-
 @Data
-public class ProdcutResponseDto {
+public class ProductInfo {
+    private Long id;
+
     private String title; // 제목(model + car_name + year)
 
     private Integer distance; // 주행 거리

--- a/backend/src/main/java/com/woochacha/backend/domain/product/service/ProductService.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/service/ProductService.java
@@ -1,12 +1,12 @@
 package com.woochacha.backend.domain.product.service;
 
-import com.woochacha.backend.domain.product.dto.ProdcutResponseDto;
+import com.woochacha.backend.domain.product.dto.ProdcutAllResponseDto;
 import com.woochacha.backend.domain.product.dto.ProductDetailResponseDto;
 
 import java.util.List;
 
 public interface ProductService {
-    List<ProdcutResponseDto> findAllProduct();
+    ProdcutAllResponseDto findAllProduct();
 
     ProductDetailResponseDto findDetailProduct(Long productId);
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/sale/dto/BranchDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/sale/dto/BranchDto.java
@@ -1,0 +1,9 @@
+package com.woochacha.backend.domain.sale.dto;
+
+import lombok.Data;
+
+@Data
+public class BranchDto {
+    private Long id;
+    private String name;
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/sale/dto/README.md
+++ b/backend/src/main/java/com/woochacha/backend/domain/sale/dto/README.md
@@ -1,1 +1,0 @@
-folder setting


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- 매물 전체 조회 기능이 작동할 때 필터링 할 수 있는 지점, 차량명, 모델, 차종, 변속기, 연료, 색상 테이블의 id, name 전체 전달하도록 구현했습니다.
- product 데이터를 전달할 때 id도 포함하도록 수정했습니다.

## 관련 이슈

- Close #78

## 세부 작업 내용

- [x] QueryDSL을 이용하여 DB에서 필터링 목록을 조회한 후 프론트에 전달하기 위해 필터링 항목별 DTO 객체 생성
    - CarNameDto, ColorDto, FuelDto, ModelDto, TrasmissionDto, TypeDto, BranchDto
- [x] Product 기능별 DTO 분리. 전체 조회 시 ProductAllResponseDto, 상세 조회 시 ProductDetailResponseDto 리턴
- [x] ProductAllResponseDto에서 기능별로 객체 분리. 매물 조회는 ProductInfo, 필터링 목록 조회는 ProductFilterInfo 
- [x] ProductInfo.java에 id 추가 

## 참고 사항

- 아래와 같은 형식으로 리턴됩니다.
- productInfo
- productFilterInfo -> typeList, modelList, carNameList, fuelList, colorList, transmissionList, bracnList -> id, name
![image](https://github.com/woorifisa-projects/woochacha/assets/93786956/ca338ad7-ec36-41ac-81b6-e527cf10ae54)
![image](https://github.com/woorifisa-projects/woochacha/assets/93786956/438eb316-fd1c-488a-90ce-b24f79c6c1cd)
