### PR TITLE
[design] 마이페이지 UI 레이아웃 구성

### DIFF
--- a/frontend/src/components/mypage/MypageCard.js
+++ b/frontend/src/components/mypage/MypageCard.js
@@ -9,94 +9,52 @@ export default function MypageCard() {
   // TODO: API 조회 후 수정할 dummy data입니다.
   const itemDummyArr = [
     {
-      productImgUrl: 'https://source.unsplash.com/random?car',
-      carName: '멋쟁이 자동차1 게시글',
-      price: '300',
-      createdDate: '2023-07',
-      distance: '58,972',
-      carWhere: '인천',
-      productUrl: '/products/detail/1',
+      id: 14,
+      title: '기아 올 뉴 카니발 2018년형',
+      distance: 110000,
+      branch: '서울',
+      price: 2690,
+      imageUrl: 'https://woochacha.s3.ap-northeast-2.amazonaws.com/product/22%EB%82%982222/1',
     },
     {
-      productImgUrl: 'https://source.unsplash.com/random?bmw',
-      carName: '멋쟁이 자동차2',
-      price: '3000',
-      createdDate: '2023-05',
-      distance: '58,999',
-      carWhere: '대전',
-      productUrl: '/products/detail/2',
+      id: 15,
+      title: '기아 모닝 2010년형',
+      distance: 100000,
+      branch: '서울',
+      price: 270,
+      imageUrl: 'https://woochacha.s3.ap-northeast-2.amazonaws.com/product/33%EB%8B%A43333/1',
     },
     {
-      productImgUrl: 'https://source.unsplash.com/random?benz',
-      carName: '멋쟁이 자동차3',
-      price: '5000',
-      createdDate: '2023-02',
-      distance: '38,972',
-      carWhere: '부산',
-      productUrl: '/products/detail/3',
+      id: 16,
+      title: '기아 올 뉴 카니발 2018년형',
+      distance: 110000,
+      branch: '서울',
+      price: 2690,
+      imageUrl: 'https://woochacha.s3.ap-northeast-2.amazonaws.com/product/22%EB%82%982222/1',
     },
     {
-      productImgUrl: 'https://source.unsplash.com/random?car',
-      carName: '멋쟁이 자동차4',
-      price: '300',
-      createdDate: '2023-07',
-      distance: '58,972',
-      carWhere: '인천',
-      productUrl: '/products/detail/4',
+      id: 17,
+      title: '기아 모닝 2010년형',
+      distance: 100000,
+      branch: '서울',
+      price: 270,
+      imageUrl: 'https://woochacha.s3.ap-northeast-2.amazonaws.com/product/33%EB%8B%A43333/1',
     },
     {
-      productImgUrl: 'https://source.unsplash.com/random?bmw',
-      carName: '멋쟁이 자동차5',
-      price: '3000',
-      createdDate: '2023-05',
-      distance: '58,999',
-      carWhere: '대전',
-      productUrl: '/products/detail/5',
+      id: 18,
+      title: '기아 올 뉴 카니발 2018년형',
+      distance: 110000,
+      branch: '서울',
+      price: 2690,
+      imageUrl: 'https://woochacha.s3.ap-northeast-2.amazonaws.com/product/22%EB%82%982222/1',
     },
     {
-      productImgUrl: 'https://source.unsplash.com/random?benz',
-      carName: '멋쟁이 자동차6',
-      price: '5000',
-      createdDate: '2023-02',
-      distance: '38,972',
-      carWhere: '부산',
-      productUrl: '/products/detail/6',
-    },
-    {
-      productImgUrl: 'https://source.unsplash.com/random?car',
-      carName: '멋쟁이 자동차7',
-      price: '300',
-      createdDate: '2023-07',
-      distance: '58,972',
-      carWhere: '인천',
-      productUrl: '/products/detail/7',
-    },
-    {
-      productImgUrl: 'https://source.unsplash.com/random?bmw',
-      carName: '멋쟁이 자동차8',
-      price: '3000',
-      createdDate: '2023-05',
-      distance: '58,999',
-      carWhere: '대전',
-      productUrl: '/products/detail/8',
-    },
-    {
-      productImgUrl: 'https://source.unsplash.com/random?benz',
-      carName: '멋쟁이 자동차9',
-      price: '5000',
-      createdDate: '2023-02',
-      distance: '38,972',
-      carWhere: '부산',
-      productUrl: '/products/detail/9',
-    },
-    {
-      productImgUrl: 'https://source.unsplash.com/random?benz',
-      carName: '멋쟁이 자동차10',
-      price: '5000',
-      createdDate: '2023-02',
-      distance: '38,972',
-      carWhere: '부산',
-      productUrl: '/products/detail/10',
+      id: 19,
+      title: '기아 모닝 2010년형',
+      distance: 100000,
+      branch: '서울',
+      price: 270,
+      imageUrl: 'https://woochacha.s3.ap-northeast-2.amazonaws.com/product/33%EB%8B%A43333/1',
     },
   ];
 
@@ -115,7 +73,7 @@ export default function MypageCard() {
         transform: 'scale(1.03)',
       },
     },
-    cardMedia: { width: '30%' },
+    cardMedia: { width: '20%', height: '100%' },
     cardContent: { flexGrow: 1 },
   };
 
@@ -133,18 +91,16 @@ export default function MypageCard() {
       <Grid container spacing={3} sx={mypageCardCss.container}>
         {itemDummyArr.map((item) => (
           <Grid item key={item.id} xs={12} sm={12} md={12}>
-            <Card sx={mypageCardCss.card} onClick={() => handleMoveDetail(item.productUrl)}>
-              <CardMedia component="div" sx={mypageCardCss.cardMedia} image={item.productImgUrl} />
+            <Card sx={mypageCardCss.card} onClick={() => handleMoveDetail(item.id)}>
+              <CardMedia component="div" sx={mypageCardCss.cardMedia} image={item.imageUrl} />
               <CardContent sx={mypageCardCss.cardContent}>
                 <Typography gutterBottom variant="h5" component="h5">
-                  {item.carName}
+                  {item.title}
                 </Typography>
                 <Grid container my={1} gap={1}>
-                  <Chip size="small" label={`연식 : ${item.createdDate}`} />
                   <Chip size="small" label={`주행거리 : ${item.distance} km`} />
                   <Chip size="small" label={`가격 : ${item.price} 만원`} />
-                  <Chip size="small" label={`지점 : ${item.carWhere}`} />
-                  <Chip size="small" label={`작성일 : ${item.createdDate}`} />
+                  <Chip size="small" label={`지점 : ${item.branch}`} />
                 </Grid>
               </CardContent>
             </Card>

--- a/frontend/src/components/mypage/MypageCard.js
+++ b/frontend/src/components/mypage/MypageCard.js
@@ -1,0 +1,156 @@
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardMedia, Typography, Grid, Chip } from '@mui/material';
+import { useRouter } from 'next/router';
+
+export default function MypageCard() {
+  const [mounted, setMounted] = useState(false);
+  const router = useRouter();
+
+  // TODO: API 조회 후 수정할 dummy data입니다.
+  const itemDummyArr = [
+    {
+      productImgUrl: 'https://source.unsplash.com/random?car',
+      carName: '멋쟁이 자동차1 게시글',
+      price: '300',
+      createdDate: '2023-07',
+      distance: '58,972',
+      carWhere: '인천',
+      productUrl: '/products/detail/1',
+    },
+    {
+      productImgUrl: 'https://source.unsplash.com/random?bmw',
+      carName: '멋쟁이 자동차2',
+      price: '3000',
+      createdDate: '2023-05',
+      distance: '58,999',
+      carWhere: '대전',
+      productUrl: '/products/detail/2',
+    },
+    {
+      productImgUrl: 'https://source.unsplash.com/random?benz',
+      carName: '멋쟁이 자동차3',
+      price: '5000',
+      createdDate: '2023-02',
+      distance: '38,972',
+      carWhere: '부산',
+      productUrl: '/products/detail/3',
+    },
+    {
+      productImgUrl: 'https://source.unsplash.com/random?car',
+      carName: '멋쟁이 자동차4',
+      price: '300',
+      createdDate: '2023-07',
+      distance: '58,972',
+      carWhere: '인천',
+      productUrl: '/products/detail/4',
+    },
+    {
+      productImgUrl: 'https://source.unsplash.com/random?bmw',
+      carName: '멋쟁이 자동차5',
+      price: '3000',
+      createdDate: '2023-05',
+      distance: '58,999',
+      carWhere: '대전',
+      productUrl: '/products/detail/5',
+    },
+    {
+      productImgUrl: 'https://source.unsplash.com/random?benz',
+      carName: '멋쟁이 자동차6',
+      price: '5000',
+      createdDate: '2023-02',
+      distance: '38,972',
+      carWhere: '부산',
+      productUrl: '/products/detail/6',
+    },
+    {
+      productImgUrl: 'https://source.unsplash.com/random?car',
+      carName: '멋쟁이 자동차7',
+      price: '300',
+      createdDate: '2023-07',
+      distance: '58,972',
+      carWhere: '인천',
+      productUrl: '/products/detail/7',
+    },
+    {
+      productImgUrl: 'https://source.unsplash.com/random?bmw',
+      carName: '멋쟁이 자동차8',
+      price: '3000',
+      createdDate: '2023-05',
+      distance: '58,999',
+      carWhere: '대전',
+      productUrl: '/products/detail/8',
+    },
+    {
+      productImgUrl: 'https://source.unsplash.com/random?benz',
+      carName: '멋쟁이 자동차9',
+      price: '5000',
+      createdDate: '2023-02',
+      distance: '38,972',
+      carWhere: '부산',
+      productUrl: '/products/detail/9',
+    },
+    {
+      productImgUrl: 'https://source.unsplash.com/random?benz',
+      carName: '멋쟁이 자동차10',
+      price: '5000',
+      createdDate: '2023-02',
+      distance: '38,972',
+      carWhere: '부산',
+      productUrl: '/products/detail/10',
+    },
+  ];
+
+  const mypageCardCss = {
+    container: {
+      mb: 10,
+    },
+    card: {
+      height: '100%',
+      display: 'flex',
+      flexDirection: 'row',
+      '&:hover': {
+        boxShadow: 10,
+        cursor: 'pointer',
+        transition: '0.3s',
+        transform: 'scale(1.03)',
+      },
+    },
+    cardMedia: { width: '30%' },
+    cardContent: { flexGrow: 1 },
+  };
+
+  // data 불러온 이후 필터링 data에 맞게 렌더링
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const handleMoveDetail = (url) => {
+    router.push(url);
+  };
+
+  return (
+    mounted && (
+      <Grid container spacing={3} sx={mypageCardCss.container}>
+        {itemDummyArr.map((item) => (
+          <Grid item key={item.id} xs={12} sm={12} md={12}>
+            <Card sx={mypageCardCss.card} onClick={() => handleMoveDetail(item.productUrl)}>
+              <CardMedia component="div" sx={mypageCardCss.cardMedia} image={item.productImgUrl} />
+              <CardContent sx={mypageCardCss.cardContent}>
+                <Typography gutterBottom variant="h5" component="h5">
+                  {item.carName}
+                </Typography>
+                <Grid container my={1} gap={1}>
+                  <Chip size="small" label={`연식 : ${item.createdDate}`} />
+                  <Chip size="small" label={`주행거리 : ${item.distance} km`} />
+                  <Chip size="small" label={`가격 : ${item.price} 만원`} />
+                  <Chip size="small" label={`지점 : ${item.carWhere}`} />
+                  <Chip size="small" label={`작성일 : ${item.createdDate}`} />
+                </Grid>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    )
+  );
+}

--- a/frontend/src/components/mypage/MypageProfile.js
+++ b/frontend/src/components/mypage/MypageProfile.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function MypageProfile() {
+  return <div>MypageProfile</div>;
+}

--- a/frontend/src/components/mypage/MypageSidebar.js
+++ b/frontend/src/components/mypage/MypageSidebar.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Box, Container, ListItemText, MenuItem, MenuList, Paper } from '@mui/material';
+import { HEADER_MINI_MENU } from '@/constants/string';
+import { useRouter } from 'next/router';
+
+export default function MypageSidebar() {
+  const router = useRouter();
+  const userId = 1; // DUMMY_DATA
+
+  const myPageSidebarCss = {
+    container: {
+      width: '20%',
+      height: '80%',
+      mt: 3,
+    },
+    mypageMenuPaper: {
+      backgroundColor: '#D6E6F5',
+      borderRadius: '0px',
+      minWidth: '150px',
+      maxWidth: '200px',
+    },
+    mypageMenuItem: {
+      borderRadius: '0px',
+      minWidth: '150px',
+      maxWidth: '200px',
+      paddingTop: 3,
+      paddingBottom: 3,
+      '&:hover': {
+        cursor: 'pointer',
+        backgroundColor: '#B2D8FA',
+      },
+    },
+  };
+
+  const handleMove = (url) => {
+    router.push(url);
+  };
+
+  return (
+    <Container sx={myPageSidebarCss.container}>
+      <Box>
+        <Paper sx={myPageSidebarCss.mypageMenuPaper}>
+          <MenuList dense>
+            {HEADER_MINI_MENU.CONTENTS.map((selectItem, idx) => {
+              return (
+                <MenuItem
+                  sx={myPageSidebarCss.mypageMenuItem}
+                  key={idx}
+                  onClick={() => handleMove(`${selectItem.pageUrl}/${userId}`)}>
+                  <ListItemText inset>{selectItem.pageName}</ListItemText>
+                </MenuItem>
+              );
+            })}
+          </MenuList>
+        </Paper>
+      </Box>
+    </Container>
+  );
+}

--- a/frontend/src/layouts/user/UserMyPageLayout.js
+++ b/frontend/src/layouts/user/UserMyPageLayout.js
@@ -1,0 +1,76 @@
+import MypageSidebar from '@/components/mypage/MypageSidebar';
+import theme from '@/styles/theme';
+import {
+  Container,
+  CssBaseline,
+  Grid,
+  ThemeProvider,
+  responsiveFontSizes,
+  styled,
+} from '@mui/material';
+import { useEffect, useState } from 'react';
+
+export default function UserMyPageLayout(props) {
+  const { children } = props;
+  const [mounted, setMounted] = useState(false);
+  let responsiveFontTheme = responsiveFontSizes(theme);
+
+  // data 불러온 이후 필터링 data에 맞게 렌더링
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const LayoutRoot = styled('div')(() => ({
+    display: 'flex',
+    flex: '1 1 auto',
+    maxWidth: '100%',
+    minWidth: '300px',
+    paddingLeft: '0px',
+  }));
+
+  const LayoutContainer = styled('div')({
+    display: 'flex',
+    flex: '1 1 auto',
+    flexDirection: 'column',
+    width: '100%',
+    minWidth: '300px',
+  });
+
+  const productsCss = {
+    gridContent: {
+      // height: '100%',
+      display: 'flex',
+      flexDirection: 'row',
+    },
+  };
+
+  return (
+    mounted && (
+      <>
+        <ThemeProvider theme={responsiveFontTheme}>
+          <CssBaseline />
+          {/* main page */}
+          <main>
+            {/* 마이페이지 전체적인 layouts */}
+            <Grid sx={productsCss.gridContent}>
+              {/* 마이페이지 side menu */}
+              <MypageSidebar />
+
+              {/* 마이페이지 세부 항목 관련 content */}
+              {/* <Container sx={productsCss.contentContainer} maxWidth="md">
+                {children}
+              </Container> */}
+              <LayoutRoot>
+                <LayoutContainer>
+                  <Container sx={productsCss.contentContainer} maxWidth="md">
+                    {children}
+                  </Container>
+                </LayoutContainer>
+              </LayoutRoot>
+            </Grid>
+          </main>
+        </ThemeProvider>
+      </>
+    )
+  );
+}

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -4,10 +4,15 @@ import '@/styles/globals.css';
 import Layout from '@/layouts/Layout';
 
 function App({ Component, pageProps }) {
+  const EmptyLayout = ({ children }) => <>{children}</>;
+  const NestedLayout = Component.Layout || EmptyLayout;
+
   return (
     <RecoilRoot>
       <Layout>
-        <Component {...pageProps} />
+        <NestedLayout>
+          <Component {...pageProps} />
+        </NestedLayout>
       </Layout>
     </RecoilRoot>
   );

--- a/frontend/src/pages/mypage/[userId].js
+++ b/frontend/src/pages/mypage/[userId].js
@@ -1,11 +1,14 @@
 import { useEffect, useState } from 'react';
 import withAuth from '@/hooks/withAuth';
 import UserMyPageLayout from '@/layouts/user/UserMyPageLayout';
-import { Typography } from '@mui/material';
+import { Button, Typography } from '@mui/material';
 import MypageProfile from '@/components/mypage/MypageProfile';
+import { useRouter } from 'next/router';
 
 function Mypage() {
   const [mounted, setMounted] = useState(false);
+  const router = useRouter();
+  const userId = 1; // DUMMY_DATA
 
   const mypageCss = {
     mypageTitle: {
@@ -13,6 +16,10 @@ function Mypage() {
       color: '#1490ef',
       fontWeight: 'bold',
     },
+  };
+
+  const handleMove = (url) => {
+    router.push(url);
   };
 
   // data 불러온 이후 필터링 data에 맞게 렌더링
@@ -26,6 +33,12 @@ function Mypage() {
         <Typography sx={mypageCss.mypageTitle} component="h4" variant="h4" gutterBottom>
           마이페이지 - 내 프로필
         </Typography>
+        <Button
+          onClick={() => {
+            handleMove(`/mypage/profile/edit/${userId}`);
+          }}>
+          수정
+        </Button>
         <MypageProfile />
       </>
     )

--- a/frontend/src/pages/mypage/[userId].js
+++ b/frontend/src/pages/mypage/[userId].js
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import withAuth from '@/hooks/withAuth';
+import UserMyPageLayout from '@/layouts/user/UserMyPageLayout';
+import { Typography } from '@mui/material';
+import MypageProfile from '@/components/mypage/MypageProfile';
+
+function Mypage() {
+  const [mounted, setMounted] = useState(false);
+
+  const mypageCss = {
+    mypageTitle: {
+      my: 10,
+      color: '#1490ef',
+      fontWeight: 'bold',
+    },
+  };
+
+  // data 불러온 이후 필터링 data에 맞게 렌더링
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return (
+    mounted && (
+      <>
+        <Typography sx={mypageCss.mypageTitle} component="h4" variant="h4" gutterBottom>
+          마이페이지 - 내 프로필
+        </Typography>
+        <MypageProfile />
+      </>
+    )
+  );
+}
+
+// side menu 레이아웃
+Mypage.Layout = withAuth(UserMyPageLayout);
+export default Mypage;

--- a/frontend/src/pages/mypage/index.js
+++ b/frontend/src/pages/mypage/index.js
@@ -1,8 +1,0 @@
-import withAuth from '@/hooks/withAuth';
-import React from 'react';
-
-function Mypage() {
-  return <div>마이페이지</div>;
-}
-
-export default withAuth(Mypage);

--- a/frontend/src/pages/mypage/profile/edit/[userId].js
+++ b/frontend/src/pages/mypage/profile/edit/[userId].js
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import withAuth from '@/hooks/withAuth';
+import UserMyPageLayout from '@/layouts/user/UserMyPageLayout';
+import { Typography } from '@mui/material';
+import MypageProfile from '@/components/mypage/MypageProfile';
+
+function ProfileEdit() {
+  const [mounted, setMounted] = useState(false);
+
+  const mypageCss = {
+    mypageTitle: {
+      my: 10,
+      color: '#1490ef',
+      fontWeight: 'bold',
+    },
+  };
+
+  // data 불러온 이후 필터링 data에 맞게 렌더링
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return (
+    mounted && (
+      <>
+        <Typography sx={mypageCss.mypageTitle} component="h4" variant="h4" gutterBottom>
+          마이페이지 - 내 프로필 수정
+        </Typography>
+        <MypageProfile />
+      </>
+    )
+  );
+}
+
+// side menu 레이아웃
+ProfileEdit.Layout = withAuth(UserMyPageLayout);
+export default ProfileEdit;

--- a/frontend/src/pages/mypage/purchase-request/[userId].js
+++ b/frontend/src/pages/mypage/purchase-request/[userId].js
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import withAuth from '@/hooks/withAuth';
+import UserMyPageLayout from '@/layouts/user/UserMyPageLayout';
+import { Grid, Pagination, Typography } from '@mui/material';
+import MypageCard from '@/components/mypage/MypageCard';
+
+function PurchaseRequest() {
+  const [mounted, setMounted] = useState(false);
+
+  const mypageCss = {
+    mypageTitle: {
+      my: 10,
+      color: '#1490ef',
+      fontWeight: 'bold',
+    },
+    pagination: { display: 'flex', justifyContent: 'center', my: 8 },
+  };
+
+  // data 불러온 이후 필터링 data에 맞게 렌더링
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return (
+    mounted && (
+      <>
+        <Typography sx={mypageCss.mypageTitle} component="h4" variant="h4" gutterBottom>
+          마이페이지 - 구매요청이력
+        </Typography>
+        <MypageCard />
+        {/* pagination */}
+        <Grid sx={mypageCss.pagination}>
+          <Pagination count={10} />
+        </Grid>
+      </>
+    )
+  );
+}
+
+// side menu 레이아웃
+PurchaseRequest.Layout = withAuth(UserMyPageLayout);
+export default PurchaseRequest;

--- a/frontend/src/pages/mypage/purchase/[userId].js
+++ b/frontend/src/pages/mypage/purchase/[userId].js
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import withAuth from '@/hooks/withAuth';
+import UserMyPageLayout from '@/layouts/user/UserMyPageLayout';
+import { Grid, Pagination, Typography } from '@mui/material';
+import MypageCard from '@/components/mypage/MypageCard';
+
+function Purchase() {
+  const [mounted, setMounted] = useState(false);
+
+  const mypageCss = {
+    mypageTitle: {
+      my: 10,
+      color: '#1490ef',
+      fontWeight: 'bold',
+    },
+    pagination: { display: 'flex', justifyContent: 'center', my: 8 },
+  };
+
+  // data 불러온 이후 필터링 data에 맞게 렌더링
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return (
+    mounted && (
+      <>
+        <Typography sx={mypageCss.mypageTitle} component="h4" variant="h4" gutterBottom>
+          마이페이지 - 구매이력
+        </Typography>
+        <MypageCard />
+        {/* pagination */}
+        <Grid sx={mypageCss.pagination}>
+          <Pagination count={10} />
+        </Grid>
+      </>
+    )
+  );
+}
+
+// side menu 레이아웃
+Purchase.Layout = withAuth(UserMyPageLayout);
+export default Purchase;

--- a/frontend/src/pages/mypage/purchase/[userId].js
+++ b/frontend/src/pages/mypage/purchase/[userId].js
@@ -1,11 +1,18 @@
 import { useEffect, useState } from 'react';
 import withAuth from '@/hooks/withAuth';
 import UserMyPageLayout from '@/layouts/user/UserMyPageLayout';
-import { Grid, Pagination, Typography } from '@mui/material';
+import { Button, Grid, Pagination, Typography } from '@mui/material';
 import MypageCard from '@/components/mypage/MypageCard';
+import { useRouter } from 'next/router';
 
 function Purchase() {
   const [mounted, setMounted] = useState(false);
+  const router = useRouter();
+  const userId = 1; // DUMMY_DATA
+
+  const handleMove = (url) => {
+    router.push(url);
+  };
 
   const mypageCss = {
     mypageTitle: {
@@ -27,6 +34,12 @@ function Purchase() {
         <Typography sx={mypageCss.mypageTitle} component="h4" variant="h4" gutterBottom>
           마이페이지 - 구매이력
         </Typography>
+        <Button
+          onClick={() => {
+            handleMove(`/mypage/purchase-request/${userId}`);
+          }}>
+          구매요청이력
+        </Button>
         <MypageCard />
         {/* pagination */}
         <Grid sx={mypageCss.pagination}>

--- a/frontend/src/pages/mypage/registered/[userId].js
+++ b/frontend/src/pages/mypage/registered/[userId].js
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import withAuth from '@/hooks/withAuth';
+import UserMyPageLayout from '@/layouts/user/UserMyPageLayout';
+import { Grid, Pagination, Typography } from '@mui/material';
+import MypageCard from '@/components/mypage/MypageCard';
+
+function RegisteredItem() {
+  const [mounted, setMounted] = useState(false);
+
+  const mypageCss = {
+    mypageTitle: {
+      my: 10,
+      color: '#1490ef',
+      fontWeight: 'bold',
+    },
+    pagination: { display: 'flex', justifyContent: 'center', my: 8 },
+  };
+
+  // data 불러온 이후 필터링 data에 맞게 렌더링
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return (
+    mounted && (
+      <>
+        <Typography sx={mypageCss.mypageTitle} component="h4" variant="h4" gutterBottom>
+          마이페이지 - 등록한 게시글(매물)정보 조회
+        </Typography>
+        <MypageCard />
+        {/* pagination */}
+        <Grid sx={mypageCss.pagination}>
+          <Pagination count={10} />
+        </Grid>
+      </>
+    )
+  );
+}
+
+// side menu 레이아웃
+RegisteredItem.Layout = withAuth(UserMyPageLayout);
+export default RegisteredItem;

--- a/frontend/src/pages/mypage/registered/[userId].js
+++ b/frontend/src/pages/mypage/registered/[userId].js
@@ -1,11 +1,15 @@
 import { useEffect, useState } from 'react';
 import withAuth from '@/hooks/withAuth';
 import UserMyPageLayout from '@/layouts/user/UserMyPageLayout';
-import { Grid, Pagination, Typography } from '@mui/material';
+import { Button, Grid, Pagination, Typography } from '@mui/material';
 import MypageCard from '@/components/mypage/MypageCard';
+import { useRouter } from 'next/router';
 
 function RegisteredItem() {
   const [mounted, setMounted] = useState(false);
+  const router = useRouter();
+  const userId = 1; // DUMMY_DATA
+  const productId = 1; // DUMMY_DATA
 
   const mypageCss = {
     mypageTitle: {
@@ -14,6 +18,10 @@ function RegisteredItem() {
       fontWeight: 'bold',
     },
     pagination: { display: 'flex', justifyContent: 'center', my: 8 },
+  };
+
+  const handleMove = (url) => {
+    router.push(url);
   };
 
   // data 불러온 이후 필터링 data에 맞게 렌더링
@@ -27,6 +35,12 @@ function RegisteredItem() {
         <Typography sx={mypageCss.mypageTitle} component="h4" variant="h4" gutterBottom>
           마이페이지 - 등록한 게시글(매물)정보 조회
         </Typography>
+        <Button
+          onClick={() => {
+            handleMove(`/mypage/registered/edit/${userId}/${productId}`);
+          }}>
+          등록한 게시글 수정
+        </Button>
         <MypageCard />
         {/* pagination */}
         <Grid sx={mypageCss.pagination}>

--- a/frontend/src/pages/mypage/registered/edit/[userId]/[productId].js
+++ b/frontend/src/pages/mypage/registered/edit/[userId]/[productId].js
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import withAuth from '@/hooks/withAuth';
+import UserMyPageLayout from '@/layouts/user/UserMyPageLayout';
+import { Typography } from '@mui/material';
+import MypageCard from '@/components/mypage/MypageCard';
+
+function RegisteredEdit() {
+  const [mounted, setMounted] = useState(false);
+
+  const mypageCss = {
+    mypageTitle: {
+      my: 10,
+      color: '#1490ef',
+      fontWeight: 'bold',
+    },
+  };
+
+  // data 불러온 이후 필터링 data에 맞게 렌더링
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return (
+    mounted && (
+      <>
+        <Typography sx={mypageCss.mypageTitle} component="h4" variant="h4" gutterBottom>
+          마이페이지 - 차량게시글 수정
+        </Typography>
+        <MypageCard />
+      </>
+    )
+  );
+}
+
+// side menu 레이아웃
+RegisteredEdit.Layout = withAuth(UserMyPageLayout);
+export default RegisteredEdit;

--- a/frontend/src/pages/mypage/sale-request/[userId].js
+++ b/frontend/src/pages/mypage/sale-request/[userId].js
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import withAuth from '@/hooks/withAuth';
+import UserMyPageLayout from '@/layouts/user/UserMyPageLayout';
+import { Grid, Pagination, Typography } from '@mui/material';
+import MypageCard from '@/components/mypage/MypageCard';
+
+function SaleRequest() {
+  const [mounted, setMounted] = useState(false);
+
+  const mypageCss = {
+    mypageTitle: {
+      my: 10,
+      color: '#1490ef',
+      fontWeight: 'bold',
+    },
+    pagination: { display: 'flex', justifyContent: 'center', my: 8 },
+  };
+
+  // data 불러온 이후 필터링 data에 맞게 렌더링
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return (
+    mounted && (
+      <>
+        <Typography sx={mypageCss.mypageTitle} component="h4" variant="h4" gutterBottom>
+          마이페이지 - 판매요청이력
+        </Typography>
+        <MypageCard />
+        {/* pagination */}
+        <Grid sx={mypageCss.pagination}>
+          <Pagination count={10} />
+        </Grid>
+      </>
+    )
+  );
+}
+
+// side menu 레이아웃
+SaleRequest.Layout = withAuth(UserMyPageLayout);
+export default SaleRequest;

--- a/frontend/src/pages/mypage/sale/[userId].js
+++ b/frontend/src/pages/mypage/sale/[userId].js
@@ -1,11 +1,18 @@
 import { useEffect, useState } from 'react';
 import withAuth from '@/hooks/withAuth';
 import UserMyPageLayout from '@/layouts/user/UserMyPageLayout';
-import { Grid, Pagination, Typography } from '@mui/material';
+import { Button, Grid, Pagination, Typography } from '@mui/material';
 import MypageCard from '@/components/mypage/MypageCard';
+import { useRouter } from 'next/router';
 
 function Sale() {
   const [mounted, setMounted] = useState(false);
+  const router = useRouter();
+  const userId = 1; // DUMMY_DATA
+
+  const handleMove = (url) => {
+    router.push(url);
+  };
 
   const mypageCss = {
     mypageTitle: {
@@ -27,6 +34,12 @@ function Sale() {
         <Typography sx={mypageCss.mypageTitle} component="h4" variant="h4" gutterBottom>
           마이페이지 - 판매이력
         </Typography>
+        <Button
+          onClick={() => {
+            handleMove(`/mypage/sale-request/${userId}`);
+          }}>
+          등록한 게시글 수정
+        </Button>
         <MypageCard />
         {/* pagination */}
         <Grid sx={mypageCss.pagination}>

--- a/frontend/src/pages/mypage/sale/[userId].js
+++ b/frontend/src/pages/mypage/sale/[userId].js
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import withAuth from '@/hooks/withAuth';
+import UserMyPageLayout from '@/layouts/user/UserMyPageLayout';
+import { Grid, Pagination, Typography } from '@mui/material';
+import MypageCard from '@/components/mypage/MypageCard';
+
+function Sale() {
+  const [mounted, setMounted] = useState(false);
+
+  const mypageCss = {
+    mypageTitle: {
+      my: 10,
+      color: '#1490ef',
+      fontWeight: 'bold',
+    },
+    pagination: { display: 'flex', justifyContent: 'center', my: 8 },
+  };
+
+  // data 불러온 이후 필터링 data에 맞게 렌더링
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return (
+    mounted && (
+      <>
+        <Typography sx={mypageCss.mypageTitle} component="h4" variant="h4" gutterBottom>
+          마이페이지 - 판매이력
+        </Typography>
+        <MypageCard />
+        {/* pagination */}
+        <Grid sx={mypageCss.pagination}>
+          <Pagination count={10} />
+        </Grid>
+      </>
+    )
+  );
+}
+
+// side menu 레이아웃
+Sale.Layout = withAuth(UserMyPageLayout);
+export default Sale;


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- 마이페이지의 기본적인 레이아웃을 구성

## 관련 이슈

- Close #30 

## 세부 작업 내용

- [x] 마이페이지 사이드바 구현
- [x] 마이페이지 중첩 레이아웃
- [x] 마이페이지 기본 라우터 구현
- [x] 마이페이지 내 목록 리스트 조회 구현

## 참고 사항

- 마이페이지의 상세 페이지 부분들은 따로 이슈를 생성해서 구현하겠습니다!
기본적인 마이페이지의 레이아웃만 생성한 상태입니다.
- 결과물
![mypage-01](https://github.com/woorifisa-projects/woochacha/assets/81960250/6181b760-9e71-4605-9362-0b77fd6d6ae1)


