### PR TITLE
[Chore] 등록한 매물, 판매이력, 구매이력 모두 status 반환데이터 추가

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/ProductResponseDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/ProductResponseDto.java
@@ -18,13 +18,16 @@ public class ProductResponseDto {
 
     private Long productId; // 게시글 id (상세페이지로 이동할떄 사용)
 
-    public ProductResponseDto(String title, Integer distance, String branch, Integer price, String imageUrl, Long productId) {
+    private String status;
+
+    public ProductResponseDto(String title, Integer distance, String branch, Integer price, String imageUrl, Long productId, String status) {
         this.title = title;
         this.distance = distance;
         this.branch = branch;
         this.price = price;
         this.imageUrl = imageUrl;
         this.productId = productId;
+        this.status = status;
     }
 
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/repository/MypageRepository.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/repository/MypageRepository.java
@@ -19,12 +19,13 @@ public interface MypageRepository extends JpaRepository<SaleForm, Long> {
             "CAST(sf.branch.name AS string) AS branch, " +
             "p.price, " +
             "ci.imageUrl, " +
-            "p.id " +
+            "p.id, " +
+            "p.status.id " +
             "FROM CarImage ci " +
             "JOIN ci.product p " +
             "JOIN p.carDetail cd " +
             "JOIN p.saleForm sf " +
-            "WHERE p.status.id = 4 " +
+            "WHERE p.status.id = 4 OR p.status.id = 6 OR p.status.id = 9 " +
             "AND ci.imageUrl LIKE '%/1' " +
             "AND sf.member.id = :memberId " +
             "ORDER BY p.createdAt ASC ")
@@ -37,7 +38,8 @@ public interface MypageRepository extends JpaRepository<SaleForm, Long> {
             "CAST(sf.branch.name AS string) AS branch, " +
             "p.price, " +
             "ci.imageUrl, " +
-            "p.id " +
+            "p.id, " +
+            "p.status.id " +
             "FROM CarImage ci " +
             "JOIN ci.product p " +
             "JOIN p.carDetail cd " +
@@ -55,7 +57,8 @@ public interface MypageRepository extends JpaRepository<SaleForm, Long> {
             "CAST(sf.branch.name AS string) AS branch, " +
             "p.price, " +
             "ci.imageUrl, " +
-            "p.id " +
+            "p.id, " +
+            "p.status.id " +
             "FROM Transaction tr " +
             "JOIN tr.purchaseForm pf " +
             "JOIN tr.saleForm sf " +

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
@@ -31,6 +31,17 @@ public class MypageServiceImpl implements MypageService {
 
     // JPQL로 조회한 결과 ProductResponseDto로 변환
     private ProductResponseDto arrayToProductResponseDto(Object[] array) {
+        // 향후 switch문으로 리팩토링 예정
+        String status;
+        if (array[6].toString().equals("4")){
+            status = "판매중";
+        } else if (array[6].toString().equals("6")) {
+            status = "삭제신청완료";
+        } else if (array[6].toString().equals("5")){
+            status = "판매완료";
+        } else {
+            status = "수정신청완료";
+        }
         return ProductResponseDto.builder()
                 .title((String) array[0])
                 .distance((Integer) array[1])
@@ -38,13 +49,14 @@ public class MypageServiceImpl implements MypageService {
                 .price((Integer) array[3])
                 .imageUrl((String) array[4])
                 .productId((Long) array[5])
+                .status(status)
                 .build();
     }
 
     // JPQL로 조회한 결과 PurchaseReqeustListDto로 변환
     private PurchaseReqeustListDto arrayToPurchaseReqeustListDto(Object[] array){
         String status;
-        if (array[5].equals(0)){
+        if (array[5].toString().equals("0")){
             status = "미검토";
         }else{
             status = "검토";

--- a/backend/src/main/java/com/woochacha/backend/domain/status/entity/CarStatusList.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/status/entity/CarStatusList.java
@@ -1,6 +1,6 @@
 package com.woochacha.backend.domain.status.entity;
 
 public enum CarStatusList {
-    반려, 심사중, 심사완료, 판매중, 판매완료, 삭제접수완료, 삭제승인완료, 비공개
+    반려, 심사중, 심사완료, 판매중, 판매완료, 삭제접수완료, 삭제승인완료, 비공개, 수정신청완료, 수정승인완료
 }
 


### PR DESCRIPTION
## 구현 기능

마이페이지의 등록한 매물, 판매이력, 구매이력에서 모두 status까지 프론트에 데이터 전송하도록 수정

## 관련 이슈

- Close #96 

## 세부 작업 내용

- [x] 등록한 매물, 판매이력, 구매이력 모두 status 반환데이터 추가 (Dto, JPQL 수정)

## 참고 사항

- 리뷰어에게 참고할만한 사항을 입력해주세요.

[프론트에 전달되는 데이터]
<img width="678" alt="image" src="https://github.com/woorifisa-projects/woochacha/assets/61819350/c292a9ca-1f91-4ff5-8b7f-4ac6fbd865d1">

- 등록한 매물 확인하는 곳에서 기존엔 "판매중"인 매물만 보여줬으니, "판매중", "삭제신청완료", "수정신청완료"매물 모두 보여주게 되어 status 정보를 보여줄 수 있도록 반환 값으로 status를 추가했습니다 !

- 과거 pr, 피그마 모두 사진 수정해두겠습니다 !