### PR TITLE
[feat] 차량 accident의 block id 값을 가지고와 history를 조회하는 기능 구현

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/qldb/service/QldbService.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/qldb/service/QldbService.java
@@ -11,7 +11,7 @@ public interface QldbService {
     String getMetaIdValue(String carNum, String tableName);
 
     // QLDB에 저장된 history를 차량 번호에 따른 차량 사고 종류와 사고 내역에 대해서 일치하는 history의 개수를 count한다.
-    int accidentHistoryInfo(String metaId, String accidentType, String accidentDesc);
+    int accidentHistoryInfo(String metaId, String accidentDesc);
 
     List<CarInspectionInfoDto> getQldbCarInfoList(String carMetaId, String accidentMetaId, String exchangeMetaId);
 

--- a/backend/src/main/java/com/woochacha/backend/domain/qldb/service/serviceImpl/QldbServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/qldb/service/serviceImpl/QldbServiceImpl.java
@@ -36,10 +36,8 @@ public class QldbServiceImpl implements QldbService {
                 Result result = txn.execute(
                         "SELECT r.car_owner_name, r.car_owner_phone FROM car AS r WHERE r.car_num=?", ionSys.newString(carNum));
                 IonStruct ionStruct = (IonStruct) result.iterator().next();
-                IonString ionStringOwnerName = (IonString) ionStruct.get("car_owner_name");
-                IonString ionStringOwnerPhone = (IonString) ionStruct.get("car_owner_phone");
-                ownerName = ionStringOwnerName.stringValue();
-                ownerPhone = ionStringOwnerPhone.stringValue();
+                ownerName = ((IonString) ionStruct.get("car_owner_name")).stringValue();
+                ownerPhone = ((IonString) ionStruct.get("car_owner_phone")).stringValue();
             });
             return Pair.of(ownerName, ownerPhone);
         } catch (Exception e) {
@@ -55,8 +53,7 @@ public class QldbServiceImpl implements QldbService {
                 Result result = txn.execute(
                         "SELECT r_id FROM " + tableName + " AS r BY r_id WHERE r.car_num=?", ionSys.newString(carNum));
                 IonStruct ionStruct = (IonStruct) result.iterator().next();
-                IonString ionString = (IonString) ionStruct.get("r_id");
-                metaId = ionString.stringValue();
+                metaId = ((IonString) ionStruct.get("r_id")).stringValue();
             });
             return metaId;
         } catch (Exception e) {
@@ -73,8 +70,7 @@ public class QldbServiceImpl implements QldbService {
                         "SELECT COUNT(*) FROM history(car_accident) AS r WHERE r.metadata.id =? AND r.data.accident_desc =?",
                         ionSys.newString(metaId), ionSys.newString(accidentDesc));
                 IonStruct ionStruct = (IonStruct) result.iterator().next();
-                IonInt ionInt = (IonInt) ionStruct.get("_1");
-                countAccidentHistory = ionInt.intValue();
+                countAccidentHistory = ((IonInt) ionStruct.get("_1")).intValue();
             });
             return countAccidentHistory;
         } catch (Exception e) {

--- a/backend/src/main/java/com/woochacha/backend/domain/sale/service/SaleFormApplyServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/sale/service/SaleFormApplyServiceImpl.java
@@ -42,7 +42,7 @@ public class SaleFormApplyServiceImpl implements SaleFormApplyService{
         String memberPhone = member.getPhone();
         Pair<String, String> ownerInfo = qldbService.getCarOwnerInfo(carNum);
         String historyId = qldbService.getMetaIdValue(carNum, "car_accident");
-        int countAccident = qldbService.accidentHistoryInfo(historyId, "침수사고","전손침수");
+        int countAccident = qldbService.accidentHistoryInfo(historyId, "전손침수");
         String owner = ownerInfo.getFirst();
         String ownerPhone = ownerInfo.getSecond();
         return memberName.equals(owner) && memberPhone.equals(ownerPhone) && countAccident == 0;


### PR DESCRIPTION
## 구현 기능

- 차량 accident의 block id 값을 가지고와 history를 조회하는 기능 구현
## 관련 이슈

- Close #107

## 세부 작업 내용

- [x] 차량 소유주 비교하는 로직에서 1개의 데이터 값만 가지고 오기 때문에 for문을 사용하지 않는 코드로 구현
- [x] 차량 accident block의 id값을 가지고 오는 로직 구현
- [x]  id값을 통해 history를 조회하는 로직 구현

## 참고 사항

- 차량 데이터를 보냈을 때, 등록 가능하면 true 불가능하면 false를 return하는데 현재 return값을 다른 값으로 바꾸려고 생각하고 있습니다.
![image](https://github.com/woorifisa-projects/woochacha/assets/87774238/b0859d21-d9b5-4e1c-bc7e-e0a8c4df8a8d)
- 1. qldb에 저장된 차량 소유주와 소유주의 핸드폰 번호를 불러온다.
- 2. 차량 번호에 따른 사고 이력에 대한 block의 id값을 불러온다.
- 3. 그 id값에 따른 전손침수 이력의 횟수를 불러온다.
- 4. 하나라도 일치하지 않을 시 false return
![image](https://github.com/woorifisa-projects/woochacha/assets/87774238/65ac5f5b-1503-4339-9b46-ec459a9fec4b)

