### PR TITLE
[design] 마이페이지 프로필 조회 / 수정 페이지 기본 UI 레이아웃 구성

### DIFF
--- a/frontend/src/components/common/FileUpload.js
+++ b/frontend/src/components/common/FileUpload.js
@@ -1,0 +1,32 @@
+/**
+ * image
+ */
+export const handleFileUpload = (
+  event,
+  data,
+  setImageFile,
+  setEditProfileValue,
+  editProfileValue,
+) => {
+  if (event.target.files[0]) {
+    setImageFile(event.target.files[0]);
+  } else {
+    setEditProfileValue({
+      ...editProfileValue,
+      imageUrl: data.profileImage,
+    });
+    return;
+  }
+
+  // image - preview
+  const reader = new FileReader();
+
+  reader.onloadend = () => {
+    setEditProfileValue({
+      ...editProfileValue,
+      imageUrl: reader.result,
+    });
+  };
+
+  reader.readAsDataURL(event.target.files[0]);
+};

--- a/frontend/src/components/mypage/MypageProfile.js
+++ b/frontend/src/components/mypage/MypageProfile.js
@@ -1,5 +1,94 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
+import { Button, Card, CardActions, CardContent, CardMedia, Grid, Typography } from '@mui/material';
+import { useRouter } from 'next/router';
 
 export default function MypageProfile() {
-  return <div>MypageProfile</div>;
+  const router = useRouter();
+  const [mounted, setMounted] = useState(false);
+
+  const mypageProfileCss = {
+    card: {
+      maxWidth: '50rem',
+      maxHeight: '45rem',
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+      alignItems: 'center',
+      marginBottom: 10,
+      paddingY: 8,
+      textAlign: 'center',
+      boxShadow: 7,
+      borderRadius: '3rem',
+    },
+    cardMedia: {
+      width: '180px',
+      height: '180px',
+      borderRadius: '50%',
+    },
+    profileTitle: { color: '#1490ef' },
+    gridContainer: { marginTop: 5, width: 'fit-content', marginBottom: 5 },
+    buttonCard: {
+      marginBottom: 5,
+    },
+    itemTitle: {
+      fontWeight: 'bold',
+    },
+  };
+
+  const dummyData = {
+    profileImage: 'https://woochacha.s3.ap-northeast-2.amazonaws.com/profile/user1%40woorifisa.com',
+    name: '홍길동',
+    phone: '01022223333',
+    email: 'user@woorifisa.com',
+  };
+
+  const userId = 1; // DUMMY_DATA
+
+  const handleMove = (url) => {
+    router.push(url);
+  };
+
+  // data 불러온 이후 필터링 data에 맞게 렌더링
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return (
+    mounted && (
+      <Card sx={mypageProfileCss.card}>
+        <CardMedia
+          sx={mypageProfileCss.cardMedia}
+          image={dummyData.profileImage}
+          title="profile-image"
+        />
+        <CardContent>
+          <Typography gutterBottom variant="h4" component="div" sx={mypageProfileCss.profileTitle}>
+            {dummyData.name} 님
+          </Typography>
+          <Grid container spacing={2} sx={mypageProfileCss.gridContainer}>
+            <Grid item xs={6} sx={mypageProfileCss.itemTitle}>
+              전화번호
+            </Grid>
+            <Grid item xs={6}>
+              {dummyData.name}
+            </Grid>
+            <Grid item xs={6} sx={mypageProfileCss.itemTitle}>
+              이메일
+            </Grid>
+            <Grid item xs={6}>
+              {dummyData.email}
+            </Grid>
+          </Grid>
+        </CardContent>
+        <CardActions sx={mypageProfileCss.buttonCard}>
+          <Button
+            variant="contained"
+            fullWidth
+            onClick={() => handleMove(`/mypage/profile/edit/${userId}`)}>
+            수정하기
+          </Button>
+        </CardActions>
+      </Card>
+    )
+  );
 }

--- a/frontend/src/components/mypage/MypageProfileEdit.js
+++ b/frontend/src/components/mypage/MypageProfileEdit.js
@@ -1,0 +1,124 @@
+import { useEffect, useRef, useState } from 'react';
+import { Box, Button, Card, CardMedia, Grid, Stack, TextField } from '@mui/material';
+import { handleFileUpload } from '../common/FileUpload';
+import { submitEditProfile } from '@/services/profileApi';
+
+export default function MypageProfileEdit() {
+  const [mounted, setMounted] = useState(false);
+  const [editProfileValue, setEditProfileValue] = useState({
+    imageUrl: null,
+    nameValue: '',
+  });
+  const [imagefile, setImageFile] = useState(null);
+  const fileInput = useRef(null);
+
+  // DUMMY_DATA
+  const dummyData = {
+    profileImage: 'https://woochacha.s3.ap-northeast-2.amazonaws.com/profile/user1%40woorifisa.com',
+    name: '홍길동',
+    phone: '01022223333',
+    email: 'user@woorifisa.com',
+  };
+  const userId = 1;
+
+  /**
+   * 이름 변경
+   */
+  const handleChangeName = (e) => {
+    setEditProfileValue({
+      ...editProfileValue,
+      nameValue: e.target.value,
+    });
+  };
+
+  /**
+   * 수정 form 제출
+   */
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    submitEditProfile(event, imagefile, editProfileValue, userId);
+  };
+
+  const mypageProfileCss = {
+    card: {
+      maxWidth: '50rem',
+      maxHeight: '45rem',
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+      alignItems: 'center',
+      marginBottom: 10,
+      paddingY: 8,
+      textAlign: 'center',
+      boxShadow: 7,
+      borderRadius: '3rem',
+    },
+    cardMedia: {
+      width: '180px',
+      height: '180px',
+      borderRadius: '50%',
+    },
+    button: { mt: 3, mb: 2 },
+  };
+
+  // data 불러온 이후 필터링 data에 맞게 렌더링
+  useEffect(() => {
+    setMounted(true);
+    setEditProfileValue({
+      imageUrl: dummyData.profileImage,
+      nameValue: dummyData.name,
+    });
+  }, []);
+
+  return (
+    mounted && (
+      <Card sx={mypageProfileCss.card}>
+        <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
+          <Stack direction="column" alignItems="center" spacing={2} mb={5}>
+            {editProfileValue.imageUrl && (
+              <CardMedia
+                sx={mypageProfileCss.cardMedia}
+                image={editProfileValue.imageUrl}
+                title="이미지 업로드"
+              />
+            )}
+            <label htmlFor="upload-image">
+              <input
+                id="upload-image"
+                hidden
+                accept="image/*"
+                type="file"
+                onChange={(event) =>
+                  handleFileUpload(
+                    event,
+                    dummyData,
+                    setImageFile,
+                    setEditProfileValue,
+                    editProfileValue,
+                  )
+                }
+                ref={fileInput}
+              />
+              <Button size="large" variant="outlined" component="span">
+                사진 수정하기
+              </Button>
+            </label>
+          </Stack>
+          <Grid>
+            <TextField
+              margin="normal"
+              required
+              name="name"
+              label="이름 변경"
+              value={editProfileValue.nameValue}
+              onChange={(e) => handleChangeName(e)}
+            />
+          </Grid>
+          <Button type="submit" size="large" variant="contained" sx={mypageProfileCss.button}>
+            내 프로필 수정하기
+          </Button>
+        </Box>
+      </Card>
+    )
+  );
+}

--- a/frontend/src/pages/mypage/[userId].js
+++ b/frontend/src/pages/mypage/[userId].js
@@ -1,14 +1,11 @@
 import { useEffect, useState } from 'react';
 import withAuth from '@/hooks/withAuth';
 import UserMyPageLayout from '@/layouts/user/UserMyPageLayout';
-import { Button, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import MypageProfile from '@/components/mypage/MypageProfile';
-import { useRouter } from 'next/router';
 
 function Mypage() {
   const [mounted, setMounted] = useState(false);
-  const router = useRouter();
-  const userId = 1; // DUMMY_DATA
 
   const mypageCss = {
     mypageTitle: {
@@ -16,10 +13,6 @@ function Mypage() {
       color: '#1490ef',
       fontWeight: 'bold',
     },
-  };
-
-  const handleMove = (url) => {
-    router.push(url);
   };
 
   // data 불러온 이후 필터링 data에 맞게 렌더링
@@ -33,12 +26,6 @@ function Mypage() {
         <Typography sx={mypageCss.mypageTitle} component="h4" variant="h4" gutterBottom>
           마이페이지 - 내 프로필
         </Typography>
-        <Button
-          onClick={() => {
-            handleMove(`/mypage/profile/edit/${userId}`);
-          }}>
-          수정
-        </Button>
         <MypageProfile />
       </>
     )

--- a/frontend/src/pages/mypage/profile/edit/[userId].js
+++ b/frontend/src/pages/mypage/profile/edit/[userId].js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import withAuth from '@/hooks/withAuth';
 import UserMyPageLayout from '@/layouts/user/UserMyPageLayout';
 import { Typography } from '@mui/material';
-import MypageProfile from '@/components/mypage/MypageProfile';
+import MypageProfileEdit from '@/components/mypage/MypageProfileEdit';
 
 function ProfileEdit() {
   const [mounted, setMounted] = useState(false);
@@ -26,7 +26,7 @@ function ProfileEdit() {
         <Typography sx={mypageCss.mypageTitle} component="h4" variant="h4" gutterBottom>
           마이페이지 - 내 프로필 수정
         </Typography>
-        <MypageProfile />
+        <MypageProfileEdit />
       </>
     )
   );

--- a/frontend/src/services/profileApi.js
+++ b/frontend/src/services/profileApi.js
@@ -1,0 +1,18 @@
+import { formInstance } from '@/utils/api';
+
+export const submitEditProfile = async (event, imagefile, editProfileValue, userId) => {
+  const formData = new FormData(event.currentTarget);
+  formData.append('profileImage', imagefile); // 이미지 파일값 할당
+  formData.append('name', editProfileValue.nameValue);
+
+  // FormData의 value 확인용 console.log
+  for (let value of formData.values()) {
+    console.log(value);
+  }
+  try {
+    const response = await formInstance.patch(`/mypage/profile/edit/${userId}`, formData);
+    console.log(response);
+  } catch (err) {
+    console.log(err);
+  }
+};


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- 마이페이지의 프로필 조회 및 수정 페이지 기본 레이아웃 및 이미지 프리뷰 처리 구현
## 관련 이슈

- Close #88 

## 세부 작업 내용

- [x]  마이페이지 프로필 조회 페이지
- [x] 마이페이지 프로필 수정 페이지
- [x] 마이페이지 프로필 이미지 수정 처리

## 참고 사항

- axios 로 통신처리는 back과 함께 작업하겠습니다.
- 결과물

![profile-page01](https://github.com/woorifisa-projects/woochacha/assets/81960250/54aac849-2826-4ac2-b130-4aae7134b49d)
