### PR TITLE
[Feature] 키워드 검색 기능 구현&필터링 검색 BooleanBuilder 사용 제거 리팩토링

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/product/controller/ProductController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/controller/ProductController.java
@@ -33,4 +33,9 @@ public class ProductController {
     public List<ProductInfo> findFilteredProduct(@RequestBody ProductFilterInfo productFilterInfo) {
         return productService.findFilteredProduct(productFilterInfo);
     }
+
+    @GetMapping("/search")
+    public List<ProductInfo> findSearchedProduct(@RequestParam(value="keyword") String keyword) {
+        return productService.findSearchedProduct(keyword);
+    }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/product/service/ProductService.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/service/ProductService.java
@@ -10,4 +10,6 @@ public interface ProductService {
     ProductAllResponseDto findAllProduct();
     ProductDetailResponseDto findDetailProduct(Long productId);
     List<ProductInfo> findFilteredProduct(ProductFilterInfo productFilterInfo);
+
+    List<ProductInfo> findSearchedProduct(String keyword);
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/product/service/impl/ProductServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/service/impl/ProductServiceImpl.java
@@ -1,6 +1,5 @@
 package com.woochacha.backend.domain.product.service.impl;
 
-import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -16,9 +15,9 @@ import com.woochacha.backend.domain.car.type.entity.*;
 import com.woochacha.backend.domain.member.entity.QMember;
 import com.woochacha.backend.domain.product.dto.ProductAllResponseDto;
 import com.woochacha.backend.domain.product.dto.ProductDetailResponseDto;
-import com.woochacha.backend.domain.product.dto.filter.ProductFilterInfo;
 import com.woochacha.backend.domain.product.dto.all.ProductInfo;
 import com.woochacha.backend.domain.product.dto.detail.*;
+import com.woochacha.backend.domain.product.dto.filter.ProductFilterInfo;
 import com.woochacha.backend.domain.product.entity.QCarImage;
 import com.woochacha.backend.domain.product.entity.QProduct;
 import com.woochacha.backend.domain.product.service.ProductService;
@@ -69,7 +68,7 @@ public class ProductServiceImpl implements ProductService {
         return new ProductAllResponseDto(productInfoList, productFilterInfo);
     }
 
-    private List<ProductInfo> findProductInfoList(BooleanBuilder builder) {
+    private List<ProductInfo> findProductInfoList(BooleanExpression expression) {
         return queryFactory
                 .select(Projections.fields(
                         ProductInfo.class, p.id,
@@ -82,7 +81,7 @@ public class ProductServiceImpl implements ProductService {
                 .join(b).on(b.id.eq(sf.branch.id))
                 .join(model).on(model.id.eq(cd.model.id))
                 .join(cn).on(cn.name.eq(cd.carName.name))
-                .where(p.status.id.eq((short) 4), ci.imageUrl.like("%/1").and(builder))
+                .where(p.status.id.eq((short) 4), ci.imageUrl.like("%/1").and(expression))
                 .orderBy(p.createdAt.asc())
                 .fetch();
     }
@@ -239,22 +238,20 @@ public class ProductServiceImpl implements ProductService {
     }
 
     // 동적 where 조건절 쿼리 작성
-    private BooleanBuilder dynamicSearch(ProductFilterInfo productFilterInfo) {
+    private BooleanExpression dynamicSearch(ProductFilterInfo productFilterInfo) {
         List<List<?>> productFilterInfoList = makeProductFilterInfoList(productFilterInfo);
 
-        BooleanBuilder builder = new BooleanBuilder();
-        BooleanExpression optionWhere;
+        BooleanExpression optionWhere = null;
 
         for (List<?> productOptionList : productFilterInfoList) { // 카테고리
             if (productOptionList != null) {
                 optionWhere = null;
                 for (Object o : productOptionList) { // 카테고리 내 id 조건
-                    optionWhere = dynamicSearchFields(o, optionWhere);
+                    optionWhere = addOrExpression(optionWhere, dynamicSearchFields(o, optionWhere));
                 }
-            } else continue;
-            builder.and(optionWhere); // 각 카테고리끼리 and 조건 적용
+            }
         }
-        return builder;
+        return optionWhere;
     }
 
     private List<List<?>> makeProductFilterInfoList(ProductFilterInfo productFilterInfo) {
@@ -314,5 +311,45 @@ public class ProductServiceImpl implements ProductService {
         if (optionWhere == null) optionWhere = optionExpression;
         else optionWhere = optionWhere.or(optionExpression);
         return optionWhere;
+    }
+
+    @Override
+    public List<ProductInfo> findSearchedProduct(String keyword) {
+        BooleanExpression expression = dynamicSearchWholeModelKeyword(keyword); // 모델명 검색 동적 쿼리 생성
+        List<ProductInfo> keywordSearchedByModelName = findProductInfoList(expression); // 모델명 동적 쿼리 실행
+
+        // 모델명 검색 결과가 없으면 차량명 검색 동작
+        if(keywordSearchedByModelName.isEmpty())
+            return findProductInfoList(dynamicSearchPartKeyword(keyword));
+
+        // 모델명 검색 결과가 있다면 모델명 검색 결과 리턴
+        else
+            return keywordSearchedByModelName;
+    }
+
+    private BooleanExpression dynamicSearchWholeModelKeyword(String keyword) {
+        BooleanExpression expression = null;
+        String[] keywordSplitToSpace = keyword.split(" ");
+
+        for(String eachKeyword : keywordSplitToSpace) {
+            BooleanExpression eachKeyWordModelName = cd.model.name.stringValue().eq(String.valueOf(eachKeyword));
+            expression = addOrExpression(expression, eachKeyWordModelName);
+        }
+        return expression;
+    }
+
+    private BooleanExpression dynamicSearchPartKeyword(String keyword) {
+        BooleanExpression expression = null;
+        String removeKeywordSpace = keyword.replaceAll(" ", ""); // 입력 값 공백 제거
+        char[] eachKeyWordArray = removeKeywordSpace.toCharArray(); // 입력 값의 각 문자를 배열로 저장
+
+        for(char eachKeyWord : eachKeyWordArray) { // 각 문자를 순회하며 문자마다 쿼리 조건절을 추가
+            BooleanExpression eachKeyWordModel = cd.model.name.stringValue().contains(String.valueOf(eachKeyWord));
+            expression = addOrExpression(expression, eachKeyWordModel);
+
+            BooleanExpression eachKeyWordCarName = cd.carName.name.contains(String.valueOf(eachKeyWord));
+            expression = addOrExpression(expression, eachKeyWordCarName);
+        }
+        return expression;
     }
 }


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- 차량 모델, 차량명으로 키워드를 입력하여 매물을 검색하는 기능 구현
- 기존 필터링 검색에서 BooleanBuilder 사용하는 부분을 BooleanExpression만 사용하도록 리팩토링

## 관련 이슈

- Close #114

## 세부 작업 내용

- [x] "/product/search"에 매핑되는 findSearchedProduct() 컨트롤러 생성
- [x] findSearchedProduct(keyword) 구현체 생성
- [x] 입력한 키워드가 모델명과 완전히 일치할 경우, 일치하는 해당 매물 정보만 리턴
- [x] 입력한 키워드가 모델명과 일치하지 않을 경우, 모델명 또는 차량명의 각 음절이 일치하는 매물 정보 리턴
- [x] 매물 필터링 검색은 findFilteredProduct()에서 BooleanBuilder 사용을 제거하고, BooleanExpression으로만 조건절을 연결하도록 리팩토링

## 참고 사항

- 프론트로부터 파라미터로 사용자가 입력한 키워드를 전달받습니다.
- 입력 대소문자를 구분하지 않습니다.
- 실행 결과는 아래와 같습니다.
1. 모델명과 완전히 일치하는 경우
- "현대" 입력
![image](https://github.com/woorifisa-projects/woochacha/assets/93786956/379a2a78-87c0-4c37-b6c9-fc473ddbdd03)
<br>

2. 모델명과 완전히 일치하지 않는 경우 
- "ad" 입력
![image](https://github.com/woorifisa-projects/woochacha/assets/93786956/ba515ac3-4a98-4de6-9ea9-d2486bb709d7)
<br>

- "포르셰" 입력(실제 DB에는 "포르쉐"로 저장되어있음)
![image](https://github.com/woorifisa-projects/woochacha/assets/93786956/8fd46cf8-484a-4436-a00d-13434a2d30c2)





