### PR TITLE
[Design] 판매자 내 차 판매 신청 폼 UI

### DIFF
--- a/frontend/src/pages/product/sale.js
+++ b/frontend/src/pages/product/sale.js
@@ -1,5 +1,147 @@
-import React from 'react';
+import { useState } from 'react';
+import {
+  Box,
+  Button,
+  CssBaseline,
+  TextField,
+  Container,
+  ThemeProvider,
+  InputLabel,
+  Select,
+  MenuItem,
+  Typography,
+} from '@mui/material';
+import theme from '@/styles/theme';
 
 export default function Sale() {
-  return <div>판매</div>;
+  const [carSaleData, setCarSaleData] = useState({
+    carNumber: '', // 차량번호 입력 필드
+    garageSelection: '', // 차고지 선택 필드
+  });
+
+  const [setCarNumberError, setGarageError] = useState(false);
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
+    // 차량 번호 필드가 빈 경우 에러를 표시
+    if (carSaleData.carNumber.trim() === '') {
+      setCarNumberError(true);
+    } else {
+      setCarNumberError(false);
+    }
+
+    // 차고지 선택이 빈 경우 에러를 표시
+    if (carSaleData.garageSelection.trim() === '') {
+      setGarageError(true);
+    } else {
+      setGarageError(false);
+    }
+
+    // applyForCarSale(carSaleData)
+    //   .then((response) => {
+    //     // 성공적으로 처리된 후에 수행할 작업을 추가합니다.
+    //     console.log('차량 판매 신청이 성공적으로 완료되었습니다.', response);
+    //   })
+    //   .catch((error) => {
+    //     // 오류 처리
+    //     console.error('차량 판매 신청 중 오류가 발생했습니다.', error);
+    //   });
+  };
+
+  return (
+    <ThemeProvider theme={theme}>
+      <Container component="main" maxWidth="md" sx={{ mt: 8, mb: 6 }}>
+        <CssBaseline />
+        <Box
+          display="flex"
+          flexDirection="column"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <div style={{ height: '35px' }}></div>
+          <Typography variant="h4" sx={{ fontWeight: 'bold', textAlign: 'center' }}>
+            내 차 판매 신청서 작성
+          </Typography>
+          <div style={{ height: '60px' }}></div>
+          <Box
+            display="flex"
+            flexDirection="column"
+            alignItems="flex-start"
+            width="60%"
+            sx={{ mb: 2 }}
+          >
+            <InputLabel htmlFor="carNumber" sx={{ fontSize: '1.2rem', mb: -0.5 }}>
+              차량번호
+            </InputLabel>
+            <TextField
+              margin="normal"
+              required
+              fullWidth
+              id="carNumber"
+              label="차량번호를 입력해주세요"
+              name="carNumber"
+              autoComplete="off"
+              autoFocus
+              value={carSaleData.carNumber}
+              onChange={(e) =>
+                setCarSaleData({ ...carSaleData, carNumber: e.target.value })
+              }
+            />
+          </Box>
+          <div style={{ height: '20px' }}></div> 
+          <Box
+            display="flex"
+            flexDirection="column"
+            alignItems="flex-start"
+            width="60%"
+            sx={{ mb: 2 }}
+          >
+            <InputLabel htmlFor="garageSelection" sx={{ fontSize: '1.2rem' }}>
+              차고지 선택
+            </InputLabel>
+            <Box sx={{ mb: 1.3 }}></Box>
+            <Select
+              fullWidth
+              value={carSaleData.garageSelection}
+              onChange={(e) =>
+                setCarSaleData({ ...carSaleData, garageSelection: e.target.value })
+              }
+              displayEmpty
+              inputProps={{ 'aria-label': 'Without label' }}
+              sx={{
+                '& .MuiSelect-select': {
+                  '&:focus': {
+                    background: 'transparent',
+                  },
+                  color: carSaleData.garageSelection ? 'black' : 'gray',
+                },
+              }}
+            >
+              <MenuItem value="" disabled>
+                <em>차고지 선택</em>
+              </MenuItem>
+              <MenuItem value="차고지1">차고지1</MenuItem>
+              <MenuItem value="차고지2">차고지2</MenuItem>
+              <MenuItem value="차고지3">차고지3</MenuItem>
+            </Select>
+          </Box>
+          <Box
+            display="flex"
+            justifyContent="flex-end"
+            width="60%"
+            sx={{ mt: 1, mb: 9 }}
+          >
+            <Button
+              type="submit"
+              variant="contained"
+              onClick={handleSubmit}
+            >
+              신청하기
+            </Button>
+          </Box>
+        </Box>
+      </Container>
+    </ThemeProvider>
+  );
 }


### PR DESCRIPTION
## 구현 기능

- 사용자 : 판매신청 페이지 UI 짜보았습니다.

## 관련 이슈

- Close #145 

## 세부 작업 내용

- [x] pages/product/sale.js (판매신청 페이지) UI 작성

## 참고 사항

![image](https://github.com/woorifisa-projects/woochacha/assets/61819350/eda01ee9-7ec3-4802-a3ca-d5d00620e7c2)


- 해당 페이지 피그마
<img width="651" alt="image" src="https://github.com/woorifisa-projects/woochacha/assets/61819350/5706cc57-8f5f-47a8-bc9c-a37bbb810482">

피그마 상엔 버튼이 좌측에 있지만, 버튼은 우측에 놓는 것이 더 자연스러울 것 같아 우선 우측에 배치했습니다 ! 

(소민언니) 차량번호 입력이 안되었을 경우, 차고지 선택이 안되었을 경우 에러처리 코드를 우선 넣어두긴 했는데, 코드 보실 때 이 부분 혹시 고칠 부분 있는지 봐주면 좋을 것 같아요!
