### PR TITLE
[Design] 관리자 사용자 정보 상세 수정 페이지 UI

### DIFF
--- a/frontend/src/pages/admin/members/edit/[memberId].js
+++ b/frontend/src/pages/admin/members/edit/[memberId].js
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import AdminPageLayout from '@/layouts/admin/AdminPageLayout';
-import { Box, Button, Card, CardMedia, Grid, Stack, TextField, Typography } from '@mui/material';
+import { Box, Button, Card, CardMedia, Stack, Typography } from '@mui/material';
 import withAdminAuth from '@/hooks/withAdminAuth';
+import { TextField, InputLabel } from '@mui/material';
+import { Radio, RadioGroup, FormControlLabel } from '@mui/material';
 
 function AdminUserEdit() {
   const [mounted, setMounted] = useState(false);
@@ -9,24 +11,25 @@ function AdminUserEdit() {
   const [editProfileValue, setEditProfileValue] = useState({
     imageUrl: null,
     nameValue: '',
+    isDefaultImage: false, // 기본 이미지로 변경 체크 상태
   });
   const fileInput = useRef(null);
 
   const adminUserProfileEditCss = {
     mypageTitle: {
-      my: 10,
+      my: 4,
       color: '#1490ef',
       fontWeight: 'bold',
     },
     card: {
-      maxWidth: '50rem',
+      maxWidth: '90rem',
       maxHeight: '45rem',
       display: 'flex',
       flexDirection: 'column',
       justifyContent: 'center',
       alignItems: 'center',
       marginBottom: 10,
-      paddingY: 8,
+      paddingY: 1,
       textAlign: 'center',
       boxShadow: 7,
       borderRadius: '3rem',
@@ -56,6 +59,38 @@ function AdminUserEdit() {
     // submitEditProfile(event, imagefile, editProfileValue, userId);
   };
 
+  /**
+   * "기본 이미지로 변경 체크박스 로직"
+   */
+  const handleFileUpload = (
+    event,
+    dummyData,
+    setImageFile,
+    setEditProfileValue,
+    editProfileValue,
+  ) => {
+    const selectedFile = event.target.files[0];
+
+    if (selectedFile) {
+      // "기본 이미지로 변경" 체크 여부에 따라 다르게 처리
+      if (editProfileValue.isDefaultImage) {
+        // 기본 이미지로 변경하는 로직 추가
+        setEditProfileValue({
+          ...editProfileValue,
+          imageUrl: dummyData.profileImage,
+        });
+      } else {
+        // 선택한 이미지 사용
+        setImageFile(selectedFile);
+        const imageUrl = URL.createObjectURL(selectedFile);
+        setEditProfileValue({
+          ...editProfileValue,
+          imageUrl,
+        });
+      }
+    }
+  };
+
   // data 불러온 이후 필터링 data에 맞게 렌더링
   useEffect(() => {
     setMounted(true);
@@ -68,16 +103,20 @@ function AdminUserEdit() {
   return (
     mounted && (
       <>
-        <Typography
-          sx={adminUserProfileEditCss.mypageTitle}
-          component="h4"
-          variant="h4"
-          gutterBottom>
-          관리자 페이지 - 유저 상세 정보 수정
-        </Typography>
-        <Card sx={adminUserProfileEditCss.card}>
+        <Card sx={{ ...adminUserProfileEditCss.card, marginTop: '25px' }}>
           <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
-            <Stack direction="column" alignItems="center" spacing={2} mb={5}>
+            <Typography
+              sx={{
+                ...adminUserProfileEditCss.mypageTitle,
+                borderBottom: '1.5px solid #1490ef', // 파란색 밑줄 추가
+                paddingBottom: '10px', // 파란색 밑줄 위에 공백 추가
+              }}
+              component="h4"
+              variant="h5"
+              gutterBottom>
+              수정하기
+            </Typography>
+            <Stack direction="column" alignItems="center" spacing={2} mb={1}>
               {editProfileValue.imageUrl && (
                 <CardMedia
                   sx={adminUserProfileEditCss.cardMedia}
@@ -86,37 +125,93 @@ function AdminUserEdit() {
                 />
               )}
               <label htmlFor="upload-image">
+                <input id="upload-image" hidden accept="image/*" type="file" ref={fileInput} />
+              </label>
+              <label className="checkbox-label">
                 <input
-                  id="upload-image"
-                  hidden
-                  accept="image/*"
-                  type="file"
-                  // onChange={(event) =>
-                  //   handleFileUpload(
-                  //     event,
-                  //     dummyData,
-                  //     setImageFile,
-                  //     setEditProfileValue,
-                  //     editProfileValue,
-                  //   )
-                  // }
-                  ref={fileInput}
+                  type="checkbox"
+                  checked={editProfileValue.isDefaultImage}
+                  onChange={(e) =>
+                    setEditProfileValue({
+                      ...editProfileValue,
+                      isDefaultImage: e.target.checked,
+                    })
+                  }
                 />
-                <Button size="large" variant="outlined" component="span">
-                  사진 수정하기
-                </Button>
+                기본 이미지로 변경
               </label>
             </Stack>
-            <Grid>
-              <Typography variant="h5">{editProfileValue.nameValue}</Typography>
-            </Grid>
-            <Button
-              type="submit"
-              size="large"
-              variant="contained"
-              sx={adminUserProfileEditCss.button}>
-              {dummyData.name} 님의 프로필 수정하기
-            </Button>
+            <InputLabel
+              htmlFor="nameValue"
+              sx={{ fontWeight: 'bold', fontSize: '1rem', mt: 0, mr: 24.5, color: 'gray' }}>
+              회원 이름
+            </InputLabel>
+            <TextField
+              variant="outlined"
+              fullWidth
+              disabled
+              value={editProfileValue.nameValue}
+              sx={{
+                width: 'calc(100% - 0px)',
+                height: '40px',
+                margin: '0 0px',
+                marginBottom: '10px',
+              }}
+            />
+            <Typography
+              variant="body1"
+              sx={{
+                fontWeight: 'bold',
+                fontSize: '1rem',
+                mt: 2,
+                textAlign: 'left',
+                color: 'gray',
+              }}>
+              상태
+            </Typography>
+
+            <RadioGroup
+              row // 이 부분이 라디오 박스를 가로로 표시하도록 합니다.
+              aria-label="회원 상태"
+              name="userStatus"
+              value={editProfileValue.userStatus} // 선택된 값
+              onChange={(e) => {
+                // 선택된 값을 상태에 업데이트
+                setEditProfileValue({
+                  ...editProfileValue,
+                  userStatus: e.target.value,
+                });
+              }}
+              sx={{ mt: 1, justifyContent: 'center', mt: 0 }} // 라디오 박스들을 중앙 정렬
+            >
+              <FormControlLabel
+                value="normal" // "일반"
+                control={<Radio />} // 라디오 버튼
+                label="일반" // 라벨 텍스트
+                sx={{ marginRight: '70px' }}
+              />
+              <FormControlLabel
+                value="restricted" // "이용제한" 값
+                control={<Radio />} // 라디오 버튼
+                label="이용제한" // 라벨 텍스트
+              />
+            </RadioGroup>
+            <Box sx={{ display: 'flex', justifyContent: 'center', mt: 0.5 }}>
+              <Button
+                type="button"
+                size="large"
+                variant="contained"
+                sx={{ ...adminUserProfileEditCss.button, marginRight: '10px' }}>
+                수정
+              </Button>
+              <Button
+                type="button"
+                size="large"
+                variant="contained"
+                sx={{ ...adminUserProfileEditCss.button, backgroundColor: 'navy' }}>
+                취소
+              </Button>
+            </Box>
           </Box>
         </Card>
       </>


### PR DESCRIPTION
## 구현 기능
관리자가 사용자 정보를 수정하는 페이지 UI를 짜보았습니다.

## 관련 이슈

- Close #152 

## 세부 작업 내용

- [x] pages/admin/members/edit/[memberId].js 파일에서 UI 구현 작업


## 참고 사항
- 구현 이미지
![image](https://github.com/woorifisa-projects/woochacha/assets/61819350/b475b08c-d1ce-432e-a97e-ba60e519084f)

- 해당 페이지의 피그마 이미지
![image](https://github.com/woorifisa-projects/woochacha/assets/61819350/1beef320-7525-4ee9-a511-27c13c93fe2f)

- 향후 글자 크기, 폰트, 색상 등등은 마지막 한꺼번에 다듬으면 좋을 것 같습니다 ~!~!