### PR TITLE
[Chore] 매물 관리 리스트에 활동 가능한 멤버의 정보만 보여주도록 수정

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/admin/repository/ManageProductFormRepository.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/repository/ManageProductFormRepository.java
@@ -20,7 +20,8 @@ public interface ManageProductFormRepository extends JpaRepository<Product, Long
             "JOIN p.carDetail cd " +
             "JOIN p.saleForm sf " +
             "JOIN sf.member m " +
-            "WHERE p.status.id IN (6, 9) " +
+            "WHERE p.status.id IN (6, 9) AND " +
+            "m.status = 1 " +
             "ORDER BY p.updatedAt ASC ")
     Page<Object[]> getDeleteEditForm(Pageable pageable);
 


### PR DESCRIPTION
## 구현 기능
매물 관리 리스트에 활동 가능한 멤버의 정보만 보여주도록 수정

## 관련 이슈

- Close #160 

## 세부 작업 내용

- [x] Repository의 JPQL where절에 활동 가능(status 1)인 멤버의 정보만 불러오도록 수정

## 참고 사항

