### PR TITLE
[Feature]log save API 구현&로그인, 로그아웃, 구매 신청에 로그 저장 구현

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/log/entity/Log.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/log/entity/Log.java
@@ -1,6 +1,9 @@
 package com.woochacha.backend.domain.log.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicInsert;
 
@@ -9,6 +12,9 @@ import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 @Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @Getter
 @DynamicInsert
 @Table(name = "log")
@@ -23,14 +29,21 @@ public class Log {
     private String email;
 
     @NotNull
-    private String username;
+    private String name;
 
     @CreationTimestamp
-    @NotNull
     private LocalDateTime date;
 
     @NotNull
     private String type;
 
     private String etc;
+
+    public Log(Long id, String email, String name, String type, String etc) {
+        this.id = id;
+        this.email = email;
+        this.name = name;
+        this.type = type;
+        this.etc = etc;
+    }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/log/repository/LogRepository.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/log/repository/LogRepository.java
@@ -1,0 +1,9 @@
+package com.woochacha.backend.domain.log.repository;
+
+import com.woochacha.backend.domain.log.entity.Log;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LogRepository extends JpaRepository<Log, Long> {
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/log/repository/README.md
+++ b/backend/src/main/java/com/woochacha/backend/domain/log/repository/README.md
@@ -1,1 +1,0 @@
-folder setting

--- a/backend/src/main/java/com/woochacha/backend/domain/log/service/LogService.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/log/service/LogService.java
@@ -1,0 +1,6 @@
+package com.woochacha.backend.domain.log.service;
+
+public interface LogService {
+    void savedMemberLogWithType(Long memberId, String type);
+    void savedMemberLogWithTypeAndEtc(Long memberId, String type, String etc);
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/log/service/impl/LogServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/log/service/impl/LogServiceImpl.java
@@ -7,19 +7,14 @@ import com.woochacha.backend.domain.log.repository.LogRepository;
 import com.woochacha.backend.domain.log.service.LogService;
 import com.woochacha.backend.domain.member.entity.Member;
 import com.woochacha.backend.domain.member.entity.QMember;
-import com.woochacha.backend.domain.member.repository.MemberRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Service
 @Transactional(readOnly = true)
 public class LogServiceImpl implements LogService {
-
-    private final MemberRepository memberRepository;
 
     private final LogRepository logRepository;
 
@@ -29,33 +24,23 @@ public class LogServiceImpl implements LogService {
 
     private final Logger logger = LoggerFactory.getLogger(LogService.class);
 
-    public LogServiceImpl(MemberRepository memberRepository, LogRepository logRepository, JPAQueryFactory queryFactory) {
-        this.memberRepository = memberRepository;
+    public LogServiceImpl(LogRepository logRepository, JPAQueryFactory queryFactory) {
         this.logRepository = logRepository;
         this.queryFactory = queryFactory;
     }
 
-
     @Override
     @Transactional
     public void savedMemberLogWithType(Long memberId, String type) {
-        try {
-            Member member = findMember(memberId);
+        Member member = findMember(memberId);
 
-            // 로그아웃 로그 저장
-            Log log = Log.builder()
-                    .email(member.getEmail())
-                    .name(member.getUsername())
-                    .type(type)
-                    .build();
+        Log log = Log.builder()
+                .email(member.getEmail())
+                .name(member.getUsername())
+                .type(type)
+                .build();
 
-            logger.info("##########################");
-            logger.info(log.toString());
-
-            logRepository.save(log);
-        } catch (Exception e) {
-            logger.error(e.toString());
-        }
+        logRepository.save(log);
     }
 
     @Override
@@ -79,14 +64,9 @@ public class LogServiceImpl implements LogService {
 
 
     private Member findMember(Long memberId) {
-        Member member = null;
-        Optional<Member> memberOptional = Optional.ofNullable(queryFactory
+        return queryFactory
                 .selectFrom(m)
-                .where(m.id.eq(memberId), m.id.eq(JPAExpressions.select(m.id.max()).from(m)))
-                .fetchOne());
-
-        if(memberOptional.isPresent())
-            member = memberOptional.get();
-        return member;
+                .where(m.id.eq(JPAExpressions.select(m.id.max()).from(m).where(m.id.eq(memberId))))
+                .fetchOne();
     }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/log/service/impl/LogServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/log/service/impl/LogServiceImpl.java
@@ -1,0 +1,92 @@
+package com.woochacha.backend.domain.log.service.impl;
+
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.woochacha.backend.domain.log.entity.Log;
+import com.woochacha.backend.domain.log.repository.LogRepository;
+import com.woochacha.backend.domain.log.service.LogService;
+import com.woochacha.backend.domain.member.entity.Member;
+import com.woochacha.backend.domain.member.entity.QMember;
+import com.woochacha.backend.domain.member.repository.MemberRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional(readOnly = true)
+public class LogServiceImpl implements LogService {
+
+    private final MemberRepository memberRepository;
+
+    private final LogRepository logRepository;
+
+    private final JPAQueryFactory queryFactory;
+
+    private final QMember m = QMember.member;
+
+    private final Logger logger = LoggerFactory.getLogger(LogService.class);
+
+    public LogServiceImpl(MemberRepository memberRepository, LogRepository logRepository, JPAQueryFactory queryFactory) {
+        this.memberRepository = memberRepository;
+        this.logRepository = logRepository;
+        this.queryFactory = queryFactory;
+    }
+
+
+    @Override
+    @Transactional
+    public void savedMemberLogWithType(Long memberId, String type) {
+        try {
+            Member member = findMember(memberId);
+
+            // 로그아웃 로그 저장
+            Log log = Log.builder()
+                    .email(member.getEmail())
+                    .name(member.getUsername())
+                    .type(type)
+                    .build();
+
+            logger.info("##########################");
+            logger.info(log.toString());
+
+            logRepository.save(log);
+        } catch (Exception e) {
+            logger.error(e.toString());
+        }
+    }
+
+    @Override
+    @Transactional
+    public void savedMemberLogWithTypeAndEtc(Long memberId, String type, String url) {
+        try {
+            Member member = findMember(memberId);
+
+            Log log = Log.builder()
+                    .email(member.getEmail())
+                    .name(member.getName())
+                    .type(type)
+                    .etc(url)
+                    .build();
+
+            logRepository.save(log);
+        } catch (Exception e) {
+            logger.error(e.toString());
+        }
+    }
+
+
+    private Member findMember(Long memberId) {
+        Member member = null;
+        Optional<Member> memberOptional = Optional.ofNullable(queryFactory
+                .selectFrom(m)
+                .where(m.id.eq(memberId), m.id.eq(JPAExpressions.select(m.id.max()).from(m)))
+                .fetchOne());
+
+        if(memberOptional.isPresent())
+            member = memberOptional.get();
+        return member;
+    }
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.woochacha.backend.domain.member.controller;
 
+import com.woochacha.backend.domain.log.service.LogService;
 import com.woochacha.backend.domain.member.dto.LoginRequestDto;
 import com.woochacha.backend.domain.member.dto.LoginResponseDto;
 import com.woochacha.backend.domain.member.dto.SignUpRequestDto;
@@ -7,11 +8,9 @@ import com.woochacha.backend.domain.member.dto.SignUpResponseDto;
 import com.woochacha.backend.domain.member.service.SignService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 
 @RestController
@@ -20,8 +19,11 @@ public class MemberController {
 
     private final SignService signService;
 
-    public MemberController(SignService signService) {
+    private final LogService logService;
+
+    public MemberController(SignService signService, LogService logService) {
         this.signService = signService;
+        this.logService = logService;
     }
 
     @PostMapping("/register")
@@ -30,17 +32,21 @@ public class MemberController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponseDto> login(@RequestBody LoginRequestDto loginRequestDto) {
+    public ResponseEntity<LoginResponseDto> login(@RequestBody LoginRequestDto loginRequestDto, HttpServletRequest request) {
         LoginResponseDto loginResponseDto = signService.login(loginRequestDto);
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add("Authorization", loginResponseDto.getToken());
+
+        logService.savedMemberLogWithType(loginResponseDto.getId(), "로그인");
+
         return ResponseEntity.ok()
                 .headers(httpHeaders)
                 .body(loginResponseDto);
     }
 
     @PostMapping("/logout")
-    public boolean logout() {
-        return signService.logout();
+    public ResponseEntity<Boolean> logout(@RequestParam("memberId") Long memberId) {
+        if (signService.logout(memberId)) return ResponseEntity.ok(true);
+        return ResponseEntity.ok(false);
     }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/controller/MemberController.java
@@ -37,8 +37,6 @@ public class MemberController {
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add("Authorization", loginResponseDto.getToken());
 
-        logService.savedMemberLogWithType(loginResponseDto.getId(), "로그인");
-
         return ResponseEntity.ok()
                 .headers(httpHeaders)
                 .body(loginResponseDto);

--- a/backend/src/main/java/com/woochacha/backend/domain/member/service/SignService.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/service/SignService.java
@@ -1,11 +1,14 @@
 package com.woochacha.backend.domain.member.service;
 
-import com.woochacha.backend.domain.member.dto.*;
+import com.woochacha.backend.domain.member.dto.LoginRequestDto;
+import com.woochacha.backend.domain.member.dto.LoginResponseDto;
+import com.woochacha.backend.domain.member.dto.SignUpRequestDto;
+import com.woochacha.backend.domain.member.dto.SignUpResponseDto;
 
 public interface SignService {
     SignUpResponseDto signUp(SignUpRequestDto userRequestDto);
 
     LoginResponseDto login(LoginRequestDto loginRequestDto);
 
-    boolean logout();
+    boolean logout(Long memberId);
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/member/service/impl/SignServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/service/impl/SignServiceImpl.java
@@ -1,19 +1,19 @@
 package com.woochacha.backend.domain.member.service.impl;
 
-import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.woochacha.backend.domain.member.entity.QMember;
-import com.woochacha.backend.domain.member.exception.SignResultCode;
 import com.woochacha.backend.common.ModelMapping;
 import com.woochacha.backend.domain.jwt.JwtAuthenticationFilter;
 import com.woochacha.backend.domain.jwt.JwtTokenProvider;
+import com.woochacha.backend.domain.log.service.impl.LogServiceImpl;
 import com.woochacha.backend.domain.member.dto.LoginRequestDto;
 import com.woochacha.backend.domain.member.dto.LoginResponseDto;
 import com.woochacha.backend.domain.member.dto.SignUpRequestDto;
 import com.woochacha.backend.domain.member.dto.SignUpResponseDto;
 import com.woochacha.backend.domain.member.entity.Member;
+import com.woochacha.backend.domain.member.entity.QMember;
 import com.woochacha.backend.domain.member.exception.LoginException;
+import com.woochacha.backend.domain.member.exception.SignResultCode;
 import com.woochacha.backend.domain.member.exception.SignUpException;
 import com.woochacha.backend.domain.member.repository.MemberRepository;
 import com.woochacha.backend.domain.member.service.SignService;
@@ -24,8 +24,6 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,13 +49,16 @@ public class SignServiceImpl implements SignService {
 
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
 
+    private final LogServiceImpl logService;
+
     public SignServiceImpl(JPAQueryFactory queryFactory, MemberRepository memberRepository, JwtTokenProvider jwtTokenProvider,
-                           PasswordEncoder passwordEncoder, AuthenticationManagerBuilder authenticationManagerBuilder) {
+                           PasswordEncoder passwordEncoder, AuthenticationManagerBuilder authenticationManagerBuilder, LogServiceImpl logService) {
         this.queryFactory = queryFactory;
         this.memberRepository = memberRepository;
         this.jwtTokenProvider = jwtTokenProvider;
         this.passwordEncoder = passwordEncoder;
         this.authenticationManagerBuilder = authenticationManagerBuilder;
+        this.logService = logService;
     }
 
     /*
@@ -148,6 +149,7 @@ public class SignServiceImpl implements SignService {
 
             // Authentication 객체를 createToken 메서드를 통해서 JWT Token 생성
             String jwt = jwtTokenProvider.createToken(authentication);
+
             return new LoginResponseDto(1, "성공", jwt, member.getId(), member.getName());
         } catch (Exception e) {
             return LoginException.exception(e);
@@ -155,8 +157,9 @@ public class SignServiceImpl implements SignService {
     }
 
 
-    public boolean logout() {
-
+    public boolean logout(Long memberId) {
+        // 로그아웃 로그 저장
+        logService.savedMemberLogWithType(memberId, "로그아웃");
         return true;
     }
 

--- a/backend/src/main/java/com/woochacha/backend/domain/member/service/impl/SignServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/service/impl/SignServiceImpl.java
@@ -150,6 +150,8 @@ public class SignServiceImpl implements SignService {
             // Authentication 객체를 createToken 메서드를 통해서 JWT Token 생성
             String jwt = jwtTokenProvider.createToken(authentication);
 
+            logService.savedMemberLogWithType(member.getId(), "로그인");
+
             return new LoginResponseDto(1, "성공", jwt, member.getId(), member.getName());
         } catch (Exception e) {
             return LoginException.exception(e);

--- a/backend/src/main/java/com/woochacha/backend/domain/product/controller/ProductController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/controller/ProductController.java
@@ -1,10 +1,11 @@
 package com.woochacha.backend.domain.product.controller;
 
+import com.woochacha.backend.domain.log.service.LogService;
 import com.woochacha.backend.domain.product.dto.ProductAllResponseDto;
 import com.woochacha.backend.domain.product.dto.ProductDetailResponseDto;
 import com.woochacha.backend.domain.product.dto.ProductPurchaseRequestDto;
-import com.woochacha.backend.domain.product.dto.filter.ProductFilterInfo;
 import com.woochacha.backend.domain.product.dto.all.ProductInfo;
+import com.woochacha.backend.domain.product.dto.filter.ProductFilterInfo;
 import com.woochacha.backend.domain.product.service.ProductService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,8 +18,11 @@ public class ProductController {
 
     private final ProductService productService;
 
-    public ProductController(ProductService productService) {
+    private final LogService logService;
+
+    public ProductController(ProductService productService, LogService logService) {
         this.productService = productService;
+        this.logService = logService;
     }
 
     @GetMapping
@@ -39,6 +43,7 @@ public class ProductController {
     @PostMapping("/purchase")
     public ResponseEntity<Boolean> applyProductPurchase(@RequestBody ProductPurchaseRequestDto productPurchaseRequestDto) {
         productService.applyPurchaseForm(productPurchaseRequestDto);
+        logService.savedMemberLogWithTypeAndEtc(productPurchaseRequestDto.getMemberId(), "구매 신청", "/product/" + productPurchaseRequestDto.getProductId());
         return ResponseEntity.ok(true);
     }
 

--- a/backend/src/main/java/com/woochacha/backend/domain/product/controller/ProductController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/controller/ProductController.java
@@ -43,7 +43,6 @@ public class ProductController {
     @PostMapping("/purchase")
     public ResponseEntity<Boolean> applyProductPurchase(@RequestBody ProductPurchaseRequestDto productPurchaseRequestDto) {
         productService.applyPurchaseForm(productPurchaseRequestDto);
-        logService.savedMemberLogWithTypeAndEtc(productPurchaseRequestDto.getMemberId(), "구매 신청", "/product/" + productPurchaseRequestDto.getProductId());
         return ResponseEntity.ok(true);
     }
 

--- a/backend/src/main/java/com/woochacha/backend/domain/product/dto/ProductPurchaseRequestDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/dto/ProductPurchaseRequestDto.java
@@ -1,12 +1,15 @@
 package com.woochacha.backend.domain.product.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ProductPurchaseRequestDto {
     private Long memberId;
     private Long productId;
-
 }


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- 

## 관련 이슈

- Close #164

## 세부 작업 내용

- [x] Log Entity의 username 필드명을 name으로 수정
- [x] Log Entity에서 date의 @NotNull 제거
- [x] Log Repository, Service, ServiceImple 구현
- [x] etc 여부에 따라 savedMemberLogWithType(memberId, type), savedMemberLogWithTypeAndEtc(memberId, type, uri) 구현
- [x] 로그인("/users/login"), 로그아웃("/users/logout") 로그 저장 구현 -> savedMemberLogWithType
- [x] 구매 신청("/product/purchase") 로그 저장 구현 -> savedMemberLogWithTypeAndEtc

## 참고 사항

- 로그 저장 형태
![image](https://github.com/woorifisa-projects/woochacha/assets/93786956/c8a571e5-d1a8-41cf-9ff7-f50974dc8791)


