### PR TITLE
[Feature] 상품 수정, 매물 삭제, 프로필 수정, 판매 신청 로그 저장

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/controller/MypageController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/controller/MypageController.java
@@ -91,16 +91,18 @@ public class MypageController {
                                                         @RequestBody @Valid UpdatePriceDto updatePriceDto){
         EditProductDto editProductDto = mypageService.getProductEditRequestInfo(memberId, productId);
         if (updatePriceDto.getUpdatePrice() > editProductDto.getPrice()) {
+            // TODO: 리팩토링 후, 이 부분 코드가 서비스 구현체로 들어가면 그때 "가격 변경 요청 실패" 로그 추가
             return ResponseEntity.badRequest().body("변경된 가격은 기존 가격보다 높을 수 없습니다.");
         }
-        mypageService.updatePrice(productId, updatePriceDto.getUpdatePrice());
+        mypageService.updatePrice(productId, updatePriceDto.getUpdatePrice(), memberId);
         return ResponseEntity.ok("가격 변경 요청이 완료되었습니다.");
     }
 
     // 등록한 매물 삭제 요청
     @PatchMapping("/registered/delete/{productId}")
-    private ResponseEntity<String> productDeleteRequest(@PathVariable Long productId){
-        mypageService.productDeleteRequest(productId);
+    private ResponseEntity<String> productDeleteRequest(@PathVariable Long productId,
+                                                        @RequestHeader(value = "memberId") Long memberId) {
+        mypageService.productDeleteRequest(productId, memberId);
         return ResponseEntity.ok("삭제 신청이 완료되었습니다.");
     }
 

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
@@ -3,6 +3,7 @@ package com.woochacha.backend.domain.mypage.service.impl;
 import com.woochacha.backend.common.ModelMapping;
 import com.woochacha.backend.domain.AmazonS3.dto.AmazonS3RequestDto;
 import com.woochacha.backend.domain.AmazonS3.service.AmazonS3Service;
+import com.woochacha.backend.domain.log.service.LogService;
 import com.woochacha.backend.domain.member.entity.Member;
 import com.woochacha.backend.domain.member.repository.MemberRepository;
 import com.woochacha.backend.domain.mypage.dto.*;
@@ -28,6 +29,8 @@ public class MypageServiceImpl implements MypageService {
     private final MemberRepository memberRepository;
     private final AmazonS3Service amazonS3Service;
     private final ModelMapper modelMapper = ModelMapping.getInstance();
+
+    private final LogService logService;
 
     // JPQL로 조회한 결과 ProductResponseDto로 변환
     private ProductResponseDto arrayToProductResponseDto(Object[] array) {
@@ -134,14 +137,16 @@ public class MypageServiceImpl implements MypageService {
 
     // 수정신청 폼 제출
     @Transactional
-    public void updatePrice(Long productId, Integer updatePrice){
+    public void updatePrice(Long productId, Integer updatePrice, Long memberId){
         mypageRepository.updatePrice(productId, updatePrice);
+        logService.savedMemberLogWithTypeAndEtc(memberId, "상품 가격 수정 요청", "/product/" + productId);
     }
 
     // 등록한 매물 삭제 신청
     @Transactional
-    public void productDeleteRequest(Long productId){
+    public void productDeleteRequest(Long productId, Long memberId){
         mypageRepository.requestProductDelete(productId);
+        logService.savedMemberLogWithTypeAndEtc(memberId, "상품 삭제 요청", "/product/" + productId);
     }
 
     // 프로필 수정 (GET요청 시 데이터 보여주기)
@@ -160,6 +165,9 @@ public class MypageServiceImpl implements MypageService {
         String email = memberRepository.findById(memberId).get().getEmail();
         amazonS3RequestDto.setEmail(email);
         String newProfileIamge = amazonS3Service.uploadProfile(amazonS3RequestDto);
+        // TODO: multipartfile null 해결
+
+        logService.savedMemberLogWithTypeAndEtc(memberId, "프로필 이미지 수정", newProfileIamge);
         return newProfileIamge;
     }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/product/controller/ProductController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/controller/ProductController.java
@@ -1,6 +1,5 @@
 package com.woochacha.backend.domain.product.controller;
 
-import com.woochacha.backend.domain.log.service.LogService;
 import com.woochacha.backend.domain.product.dto.ProductAllResponseDto;
 import com.woochacha.backend.domain.product.dto.ProductDetailResponseDto;
 import com.woochacha.backend.domain.product.dto.ProductPurchaseRequestDto;
@@ -18,11 +17,8 @@ public class ProductController {
 
     private final ProductService productService;
 
-    private final LogService logService;
-
-    public ProductController(ProductService productService, LogService logService) {
+    public ProductController(ProductService productService) {
         this.productService = productService;
-        this.logService = logService;
     }
 
     @GetMapping

--- a/backend/src/main/java/com/woochacha/backend/domain/product/service/impl/ProductServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/service/impl/ProductServiceImpl.java
@@ -340,11 +340,7 @@ public class ProductServiceImpl implements ProductService {
         Product product = productRepository.findById(productPurchaseRequestDto.getProductId()).orElseThrow(() -> new RuntimeException("SaleForm not found"));
         PurchaseForm purchaseForm = PurchaseForm.builder().member(member).product(product).build();
         purchaseFormRepository.save(purchaseForm);
-        try {
-            logService.savedMemberLogWithTypeAndEtc(productPurchaseRequestDto.getMemberId(), "구매 신청", "/product/" + productPurchaseRequestDto.getProductId());
-        } catch (Exception e) {
-            logger.info("########### " + e.toString());
-        }
+        logService.savedMemberLogWithTypeAndEtc(productPurchaseRequestDto.getMemberId(), "구매 신청", "/product/" + productPurchaseRequestDto.getProductId());
     }
 
     public List<ProductInfo> findSearchedProduct(String keyword) {

--- a/backend/src/main/java/com/woochacha/backend/domain/sale/controller/SaleController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/sale/controller/SaleController.java
@@ -4,7 +4,6 @@ package com.woochacha.backend.domain.sale.controller;
 import com.woochacha.backend.domain.member.repository.MemberRepository;
 import com.woochacha.backend.domain.sale.dto.BranchDto;
 import com.woochacha.backend.domain.sale.dto.SaleFormRequestDto;
-import com.woochacha.backend.domain.sale.entity.Branch;
 import com.woochacha.backend.domain.sale.repository.BranchRepository;
 import com.woochacha.backend.domain.sale.service.SaleFormApplyService;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/woochacha/backend/domain/sale/service/SaleFormApplyService.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/sale/service/SaleFormApplyService.java
@@ -1,7 +1,7 @@
 package com.woochacha.backend.domain.sale.service;
 
 import com.woochacha.backend.domain.sale.dto.BranchDto;
-import com.woochacha.backend.domain.sale.entity.Branch;
+
 import java.util.List;
 
 public interface SaleFormApplyService {

--- a/backend/src/main/java/com/woochacha/backend/domain/sale/service/SaleFormApplyServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/sale/service/SaleFormApplyServiceImpl.java
@@ -1,6 +1,7 @@
 package com.woochacha.backend.domain.sale.service;
 
 import com.woochacha.backend.common.ModelMapping;
+import com.woochacha.backend.domain.log.service.LogService;
 import com.woochacha.backend.domain.member.entity.Member;
 import com.woochacha.backend.domain.member.repository.MemberRepository;
 import com.woochacha.backend.domain.qldb.service.QldbService;
@@ -30,6 +31,7 @@ public class SaleFormApplyServiceImpl implements SaleFormApplyService{
     private final QldbService qldbService;
     private final MemberRepository memberRepository;
     private final BranchRepository branchRepository;
+    private final LogService logService;
     private final ModelMapper modelMapper = ModelMapping.getInstance();
 
     //차량 신청 폼을 요청할 때, 전체 branch 리스트를 넘겨줌 (Get)
@@ -86,5 +88,6 @@ public class SaleFormApplyServiceImpl implements SaleFormApplyService{
                 .carStatus(carStatus)
                 .build();
         saleFormRepository.save(saleForm);
+        logService.savedMemberLogWithTypeAndEtc(memberId, "판매 신청폼 제출", "/admin/sales/approve/" + saleForm.getId());
     }
 }

--- a/backend/src/main/java/com/woochacha/backend/security/configs/SecurityConfig.java
+++ b/backend/src/main/java/com/woochacha/backend/security/configs/SecurityConfig.java
@@ -68,7 +68,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // JWT Token 인증방식으로 세션은 필요 없으므로 비활성화
 
-                .and()
+                .and() // TODO: 권한이 필요한 작업 전에 jwt principle과 email 비교해서 일치한 경우에만 진행되도록 리팩토링
                 .authorizeRequests()
                 .antMatchers("/", "/users/register", "/users/login", "/product/**").permitAll()
                 .antMatchers("/users/**", "/products/sale", "/s3/upload-profile", "/mypage/**").hasRole("USER")


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- 사용자 기능별 로그 저장 코드 추가

## 관련 이슈

- Close #173

## 세부 작업 내용

- [x] 사용자의 상품 수정 신청, 매물 삭제 요청, 프로필 수정, 판매 신청 폼 전송 시 로그가 저장되도록 구현


## 참고 사항

- 프로필 수정 후 로그 저장의 경우, postman에서 multipartfile null 이슈가 발생하여, 프론트엔드와 직접 axios 통신 후 로그 저장 작동 확인 예정입니다.
- 아래와 같은 형식으로 저장됩니다.
![image](https://github.com/woorifisa-projects/woochacha/assets/93786956/d9388f95-e9fb-4cdf-a84b-913191de1ba5)

