### PR TITLE
[chore] : 관리자가 변경하는 사용자의 상태의 변수 명 수정

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/manageMember/EditMemberRequestDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/manageMember/EditMemberRequestDto.java
@@ -2,10 +2,11 @@ package com.woochacha.backend.domain.admin.dto.manageMember;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
 public class EditMemberRequestDto {
     private int isChecked;
-    private Byte status;
+    private Byte isAvailable;
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/service/impl/ManageMemberServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/service/impl/ManageMemberServiceImpl.java
@@ -81,7 +81,7 @@ public class ManageMemberServiceImpl implements ManageMemberService {
         if(editMemberRequestDto.getIsChecked() == 1){
             updatedCount += memberRepository.updateMemberImage(memberId,baseUrl);
         }
-        updatedCount += memberRepository.updateMemberStatus(memberId,editMemberRequestDto.getStatus());
+        updatedCount += memberRepository.updateMemberStatus(memberId,editMemberRequestDto.getIsAvailable());
         if (updatedCount > 0) {
             // 업데이트가 성공적으로 이루어진 경우의 처리
             return "Member status updated successfully.";

--- a/backend/src/main/java/com/woochacha/backend/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/repository/MemberRepository.java
@@ -11,8 +11,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     @Modifying
-    @Query("UPDATE Member m SET m.status = :status WHERE m.id = :memberId")
-    int updateMemberStatus(@Param("memberId") Long memberId, @Param("status") Byte status);
+    @Query("UPDATE Member m SET m.isAvailable = :isAvailable WHERE m.id = :memberId")
+    int updateMemberStatus(@Param("memberId") Long memberId, @Param("isAvailable") Byte isAvailable);
     @Modifying
     @Query("UPDATE Member m SET m.profileImage = :profileImage WHERE m.id = :memberId")
     int updateMemberImage(@Param("memberId") Long memberId, @Param("profileImage") String profileImage);


### PR DESCRIPTION
## 구현 기능

- 관리자가 변경하는 사용자의 상태의 변수 명을 수정한다.

## 관련 이슈

- Close #183

## 세부 작업 내용

- [x] 프론트엔드에서 제공하는 data 변수명을 status -> isAvailable로 변경
- [x] 백엔드에서 db의 update를 status->isAvailable로 변경
