### PR TITLE
[feature] 관리자페이지 - 판매 신청 관리 목록, 판매 승인, 판매 게시글 등록 API 연동

### DIFF
--- a/frontend/src/components/admin/SaleTable.js
+++ b/frontend/src/components/admin/SaleTable.js
@@ -72,7 +72,7 @@ function TablePaginationActions(props) {
 
 // basic component
 export default function SaleTable(props) {
-  const { headerData, contentData, moveUrl, callbackFunc } = props;
+  const { headerData, contentData, moveUrl, callbackFunc, setCurrentSaleFormId } = props;
   const rows = contentData;
   const [mounted, setMounted] = useState(false);
   const [page, setPage] = useState(0);
@@ -91,8 +91,12 @@ export default function SaleTable(props) {
     setPage(0);
   };
 
-  const handleMove = (memberId) => {
-    router.push(`${moveUrl}${memberId}`);
+  const handleMove = (saleFormId) => {
+    router.push(`${moveUrl}${saleFormId}`);
+  };
+
+  const handleCurrentId = (currentId) => {
+    setCurrentSaleFormId(currentId);
   };
 
   useEffect(() => {
@@ -132,11 +136,13 @@ export default function SaleTable(props) {
               ? rows.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
               : rows
             ).map((row) => (
-              <TableRow sx={basicButtonTableCss.tableRow} key={row.id}>
+              <TableRow
+                sx={basicButtonTableCss.tableRow}
+                key={row.id}
+                onClick={() => handleCurrentId(row.id)}>
                 <TableCell align="center">{row[`${headerData[0].contentCell}`]}</TableCell>
                 <TableCell align="center">{row[`${headerData[1].contentCell}`]}</TableCell>
                 <TableCell align="center">{row[`${headerData[2].contentCell}`]}</TableCell>
-                <TableCell align="center">{row[`${headerData[3].contentCell}`]}</TableCell>
                 <TableCell align="center">
                   <Button
                     onClick={() => handleMove(row.id)}

--- a/frontend/src/pages/admin/sales/approve/[saleformId].js
+++ b/frontend/src/pages/admin/sales/approve/[saleformId].js
@@ -1,3 +1,4 @@
+// TODO: 수정하기
 import { useEffect, useRef, useState } from 'react';
 import AdminPageLayout from '@/layouts/admin/AdminPageLayout';
 import {
@@ -21,9 +22,12 @@ import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import theme from '@/styles/theme';
 import { ADMIN_APPROVE_MODAL } from '@/constants/string';
 import OneButtonModal from '@/components/common/OneButtonModal';
+import { oneApproveFormGetApi } from '@/services/adminpageApi';
 
 function AdminSalesApproveForm() {
   const [mounted, setMounted] = useState(false);
+  const [approveSaleForm, setApproveSaleForm] = useState(); // 기존 qldb 값
+  const [defaultDistance, setDefaultDistance] = useState(); // 기존 주행거리(유효성 검사용)
 
   // 교체부위 select box 관련
   const [exchangeVal, setExchangeVal] = useState({
@@ -63,19 +67,32 @@ function AdminSalesApproveForm() {
 
   let responsiveFontTheme = responsiveFontSizes(theme);
 
-  const handleSubmit = () => {
-    console.log('submit!');
-    router.push(`/admin/sales/register/${saleformId}`);
+  /**
+   * 승인 modal 창 열기 전, 주행거리 확인
+   */
+  const handleOpenModal = () => {
+    if (approveSaleForm.carDistance < defaultDistance) {
+      alert('기존 주행거리보다 작을 수 없습니다!');
+      return;
+    } else {
+      handleClickModal();
+    }
   };
 
-  const handleSaveApproveVal = (event) => {
+  /**
+   * 승인 요청
+   */
+  const handleSubmit = (event) => {
+    // TODO: submit axios 연결 여기서
+
+    router.push(`/admin/sales/register/${saleformId}`);
+    /*
     event.preventDefault();
     const data = new FormData(approveForm.current);
     console.log(approveForm);
     console.log(data);
 
     const newApproveData = {
-      /*
       distance: data.get('carDistance').trim(),
       // TODO: 교통사고 & 침수사고 둘 다 있을 경우, 어떤 식으로 데이터를 넘겨야하는지?
       carAccidentInfoDto: {
@@ -88,13 +105,13 @@ function AdminSalesApproveForm() {
         exchangeDesc: exchangeVal.exchangeDesc,
         exchangeDate: exchangeVal.exchangeDate,
       },
-      */
     };
     setApproveVal(newApproveData);
     handleClickModal();
+    */
   };
 
-  // 교체 select box func
+  // [교체] select box func
   const handleExchangeChange = (e) => {
     setExchangeVal({
       ...exchangeVal,
@@ -102,7 +119,23 @@ function AdminSalesApproveForm() {
     });
   };
 
-  // 사고유형 select box func
+  // [교체] input box func
+  const handleExchangeDescChange = (e) => {
+    setExchangeVal({
+      ...exchangeVal,
+      exchangeDesc: e.target.value,
+    });
+  };
+
+  // [교체] date box func
+  const handleExchangeDateChange = (e) => {
+    setExchangeVal({
+      ...exchangeVal,
+      exchangeDesc: e.target.value,
+    });
+  };
+
+  // [사고유형] select box func
   const handleAccidentChange = (e) => {
     setAccidentVal({
       ...accidentVal,
@@ -110,10 +143,44 @@ function AdminSalesApproveForm() {
     });
   };
 
+  // [사고유형] input box func
+  const handleAccidentDescChange = (e) => {
+    setAccidentVal({
+      ...accidentVal,
+      accidentDesc: e.target.value,
+    });
+  };
+
+  // [사고유형] date box func
+  const handleAccidentDateChange = (e) => {
+    setAccidentVal({
+      ...accidentVal,
+      accidentDesc: e.target.value,
+    });
+  };
+
+  // 가격 수정
+  const handleChangeDistance = (e) => {
+    setApproveSaleForm({
+      ...approveSaleForm,
+      carDistance: e.target.value,
+    });
+  };
+
   // data 불러온 이후 필터링 data에 맞게 렌더링
-  useEffect(() => {
-    setMounted(true);
-  }, []);
+  saleformId &&
+    useEffect(() => {
+      oneApproveFormGetApi(saleformId).then((res) => {
+        console.log(res);
+        if (res.status === 200) {
+          setApproveSaleForm(res.data);
+          setDefaultDistance(res.data.carDistance);
+        } else {
+          alert('데이터가 없습니다!');
+        }
+      });
+      setMounted(true);
+    }, []);
 
   const saleApproveFormCss = {
     approveFormTitle: {
@@ -161,231 +228,193 @@ function AdminSalesApproveForm() {
     },
   };
 
-  // TODO: axios
-  const get_dummy_data = {
-    id: 3,
-    carNum: '91가1234',
-    carOwnerName: '이차차',
-    carOwnerPhone: '01011112222',
-    carDistance: 75000,
-    carAccidentInfoList: [
-      {
-        accidentType: '침수사고',
-        accidentDesc: '반손침수',
-        accidentDate: '2023-09-03',
-      },
-    ],
-    carExchangeInfoDtoList: [
-      {
-        exchangeType: '앞문',
-        exchangeDesc: '교통사고',
-        exchangeDate: '2023-09-03',
-      },
-    ],
-  };
-
-  return (
-    mounted && (
-      <ThemeProvider theme={responsiveFontTheme}>
-        <CssBaseline />
-        <Typography
-          sx={saleApproveFormCss.approveFormTitle}
-          component="h4"
-          variant="h4"
-          gutterBottom>
-          판매 신청 관리
+  return mounted && approveSaleForm ? (
+    <ThemeProvider theme={responsiveFontTheme}>
+      <CssBaseline />
+      <Typography sx={saleApproveFormCss.approveFormTitle} component="h4" variant="h4" gutterBottom>
+        판매 신청 관리
+      </Typography>
+      {/* subtitle card */}
+      <Card sx={saleApproveFormCss.titleCard}>
+        <Typography variant="h4" sx={saleApproveFormCss.colorTypo}>
+          점검 정보 승인
         </Typography>
-        {/* subtitle card */}
-        <Card sx={saleApproveFormCss.titleCard}>
-          <Typography variant="h4" sx={saleApproveFormCss.colorTypo}>
-            점검 정보 승인
-          </Typography>
-          <ArrowForwardIcon fontSize="large" />
-          <Typography variant="h4" sx={saleApproveFormCss.subTitleTypo}>
-            차량 게시글 등록
-          </Typography>
-        </Card>
+        <ArrowForwardIcon fontSize="large" />
+        <Typography variant="h4" sx={saleApproveFormCss.subTitleTypo}>
+          차량 게시글 등록
+        </Typography>
+      </Card>
 
-        {/* contents */}
-        <Container sx={saleApproveFormCss.formContents} maxWidth="md">
-          {/* FORM CONTNETS */}
-          <Typography component="h1" variant="h4" sx={saleApproveFormCss.approveFormTitle}>
-            점검차량 정보 입력
-          </Typography>
-          <Grid container sx={saleApproveFormCss.flexBox} spacing={5}>
-            <Grid item xs={12} md={6}>
-              <Box component="form" ref={approveForm} noValidate onSubmit={handleSaveApproveVal}>
-                <Grid container spacing={2}>
-                  <Grid item xs={12}>
-                    <InputLabel htmlFor="carNum" sx={saleApproveFormCss.inputLabel}>
-                      차량번호
-                    </InputLabel>
-                    <TextField
-                      disabled
-                      fullWidth
-                      id="carNum"
-                      name="carNum"
-                      value={get_dummy_data.carNum}
-                    />
-                  </Grid>
-                  <Grid item xs={12}>
-                    <InputLabel htmlFor="carOwnerName" sx={saleApproveFormCss.inputLabel}>
-                      차량 소유주
-                    </InputLabel>
-                    <TextField
-                      disabled
-                      fullWidth
-                      id="carOwnerName"
-                      name="carOwnerName"
-                      value={get_dummy_data.carOwnerName}
-                    />
-                  </Grid>
-                  <Grid item xs={12}>
-                    <InputLabel htmlFor="carOwnerPhone" sx={saleApproveFormCss.inputLabel}>
-                      차량 소유주 번호
-                    </InputLabel>
-                    <TextField
-                      disabled
-                      fullWidth
-                      id="carOwnerPhone"
-                      name="carOwnerPhone"
-                      value={get_dummy_data.carOwnerPhone}
-                    />
-                  </Grid>
-                  <Grid item xs={12}>
-                    <InputLabel htmlFor="carDistance" sx={saleApproveFormCss.inputLabel}>
-                      주행거리
-                    </InputLabel>
-                    <TextField
-                      fullWidth
-                      id="carDistance"
-                      label="주행거리를 입력해주세요"
-                      name="carDistance"
-                      type="number"
-                    />
-                  </Grid>
-                  <Grid item xs={12}>
-                    <InputLabel id="accidentType" sx={saleApproveFormCss.inputLabel}>
-                      사고유형
-                    </InputLabel>
-                    <Select
-                      fullWidth
-                      labelId="accidentType"
-                      id="accidentTypeLabelSelect"
-                      value={accidentVal.accidentType}
-                      label="accidentType"
-                      onChange={handleAccidentChange}>
-                      <MenuItem value={1}>교통사고</MenuItem>
-                      <MenuItem value={2}>침수사고</MenuItem>
-                    </Select>
-                  </Grid>
-                  <Grid item xs={12}>
-                    <InputLabel htmlFor="accidentDesc" sx={saleApproveFormCss.inputLabel}>
-                      사고
-                    </InputLabel>
-                    <TextField
-                      fullWidth
-                      name="accidentDesc"
-                      id="accidentDesc"
-                      label="사고 이력을 입력해주세요."
-                    />
-                  </Grid>
-                  <Grid item xs={12}>
-                    <InputLabel htmlFor="carAccidentDate" sx={saleApproveFormCss.inputLabel}>
-                      사고 발생일
-                    </InputLabel>
-                    <TextField fullWidth name="carAccidentDate" id="carAccidentDate" type="date" />
-                  </Grid>
-                  <Grid item xs={12}>
-                    <InputLabel htmlFor="exchangeType" sx={saleApproveFormCss.inputLabel}>
-                      교체부위
-                    </InputLabel>
-                    <Select
-                      fullWidth
-                      labelId="exchangeType"
-                      id="exchangeTypeLabelSelect"
-                      value={exchangeVal.exchangeType}
-                      label="exchangeType"
-                      onChange={handleExchangeChange}>
-                      <MenuItem value={1}>백미러</MenuItem>
-                      <MenuItem value={2}>앞문</MenuItem>
-                      <MenuItem value={3}>뒷문</MenuItem>
-                    </Select>
-                  </Grid>
-                  <Grid item xs={12}>
-                    <InputLabel htmlFor="exchangeDesc" sx={saleApproveFormCss.inputLabel}>
-                      교체사유
-                    </InputLabel>
-                    <TextField
-                      fullWidth
-                      name="exchangeDesc"
-                      label="교체 사유를 입력해주세요."
-                      id="exchangeDesc"
-                    />
-                  </Grid>
-                </Grid>
-                <Grid sx={saleApproveFormCss.submitBtn}>
-                  <Button
-                    size="large"
-                    type="submit"
-                    variant="contained"
-                    onClick={handleSaveApproveVal}>
-                    승인 신청
-                  </Button>
-                </Grid>
-              </Box>
-            </Grid>
-
-            {/* HISTORY */}
-            <Grid item xs={12} md={6}>
+      {/* contents */}
+      <Container sx={saleApproveFormCss.formContents} maxWidth="md">
+        {/* FORM CONTNETS */}
+        <Typography component="h1" variant="h4" sx={saleApproveFormCss.approveFormTitle}>
+          점검차량 정보 입력
+        </Typography>
+        <Grid container sx={saleApproveFormCss.flexBox} spacing={5}>
+          <Grid item xs={12} md={6}>
+            <Box ref={approveForm} noValidate>
               <Grid container spacing={2}>
-                <Card sx={saleApproveFormCss.historyCard}>
-                  <Grid item xs={12} py={2}>
-                    <Typography variant="h5" fontWeight="bold">
-                      {`${get_dummy_data.carNum} 차량의 history`}
-                    </Typography>
-                  </Grid>
-                  <Grid item xs={12} py={2}>
-                    <Typography variant="h6" fontWeight="bold">
-                      사고이력 조회
-                    </Typography>
-                    {get_dummy_data.carAccidentInfoList.map((accidentItem, idx) => {
-                      return (
-                        <Typography
-                          key={
-                            idx
-                          }>{`[ ${accidentItem.accidentType} ] ${accidentItem.accidentDesc} ( ${accidentItem.accidentDate} )`}</Typography>
-                      );
-                    })}
-                  </Grid>
-                  <Grid item xs={12} py={2}>
-                    <Typography variant="h6" fontWeight="bold">
-                      교체이력 조회
-                    </Typography>
-                    {get_dummy_data.carExchangeInfoDtoList.map((exchangeItem, idx) => {
-                      return (
-                        <Typography
-                          key={
-                            idx
-                          }>{`[ ${exchangeItem.exchangeType} ] ${exchangeItem.exchangeDesc} ( ${exchangeItem.exchangeDate} )`}</Typography>
-                      );
-                    })}
-                  </Grid>
-                </Card>
+                <Grid item xs={12}>
+                  <InputLabel htmlFor="carNum" sx={saleApproveFormCss.inputLabel}>
+                    차량번호
+                  </InputLabel>
+                  <Typography variant="h5">{approveSaleForm.carNum}</Typography>
+                </Grid>
+                <Grid item xs={12}>
+                  <InputLabel htmlFor="carOwnerName" sx={saleApproveFormCss.inputLabel}>
+                    차량 소유주
+                  </InputLabel>
+                  <Typography variant="h5">{approveSaleForm.carOwnerName}</Typography>
+                </Grid>
+                <Grid item xs={12}>
+                  <InputLabel htmlFor="carOwnerPhone" sx={saleApproveFormCss.inputLabel}>
+                    차량 소유주 번호
+                  </InputLabel>
+                  <Typography variant="h5">{approveSaleForm.carOwnerPhone}</Typography>
+                </Grid>
+                <Grid item xs={12}>
+                  <InputLabel htmlFor="carDistance" sx={saleApproveFormCss.inputLabel}>
+                    주행거리
+                  </InputLabel>
+                  <TextField
+                    fullWidth
+                    id="carDistance"
+                    label="주행거리를 입력해주세요"
+                    name="carDistance"
+                    defaultValue={approveSaleForm.carDistance}
+                    onChange={handleChangeDistance}
+                    type="number"
+                  />
+                </Grid>
+                <Grid item xs={12}>
+                  <InputLabel id="accidentType" sx={saleApproveFormCss.inputLabel}>
+                    사고유형
+                  </InputLabel>
+                  <Select
+                    fullWidth
+                    labelId="accidentType"
+                    id="accidentTypeLabelSelect"
+                    value={accidentVal.accidentType}
+                    label="accidentType"
+                    onChange={handleAccidentChange}>
+                    <MenuItem value={1}>교통사고</MenuItem>
+                    <MenuItem value={2}>침수사고</MenuItem>
+                  </Select>
+                </Grid>
+                <Grid item xs={12}>
+                  <InputLabel htmlFor="accidentDesc" sx={saleApproveFormCss.inputLabel}>
+                    사고
+                  </InputLabel>
+                  <TextField
+                    fullWidth
+                    name="accidentDesc"
+                    id="accidentDesc"
+                    label="사고 이력을 입력해주세요."
+                  />
+                </Grid>
+                <Grid item xs={12}>
+                  <InputLabel htmlFor="carAccidentDate" sx={saleApproveFormCss.inputLabel}>
+                    사고 발생일
+                  </InputLabel>
+                  <TextField
+                    fullWidth
+                    name="carAccidentDate"
+                    id="carAccidentDate"
+                    type="date"
+                    onChange={handleExchangeDescChange}
+                  />
+                </Grid>
+                <Grid item xs={12}>
+                  <InputLabel htmlFor="exchangeType" sx={saleApproveFormCss.inputLabel}>
+                    교체부위
+                  </InputLabel>
+                  <Select
+                    fullWidth
+                    labelId="exchangeType"
+                    id="exchangeTypeLabelSelect"
+                    value={exchangeVal.exchangeType}
+                    label="exchangeType"
+                    onChange={handleExchangeChange}>
+                    <MenuItem value={1}>백미러</MenuItem>
+                    <MenuItem value={2}>앞문</MenuItem>
+                    <MenuItem value={3}>뒷문</MenuItem>
+                  </Select>
+                </Grid>
+                <Grid item xs={12}>
+                  <InputLabel htmlFor="exchangeDesc" sx={saleApproveFormCss.inputLabel}>
+                    교체사유
+                  </InputLabel>
+                  <TextField
+                    fullWidth
+                    name="exchangeDesc"
+                    label="교체 사유를 입력해주세요."
+                    id="exchangeDesc"
+                  />
+                </Grid>
               </Grid>
+              <Grid sx={saleApproveFormCss.submitBtn}>
+                <Button size="large" type="submit" variant="contained" onClick={handleOpenModal}>
+                  승인 신청
+                </Button>
+              </Grid>
+            </Box>
+          </Grid>
+
+          {/* HISTORY */}
+          <Grid item xs={12} md={6}>
+            <Grid container spacing={2}>
+              <Card sx={saleApproveFormCss.historyCard}>
+                <Grid item xs={12} py={2}>
+                  <Typography variant="h5" fontWeight="bold">
+                    {`${approveSaleForm.carNum} 차량의 history`}
+                  </Typography>
+                </Grid>
+                <Grid item xs={12} py={2}>
+                  <Typography variant="h6" fontWeight="bold">
+                    사고이력 조회
+                  </Typography>
+                  {approveSaleForm.carAccidentInfoDtoList.map((accidentItem, idx) => {
+                    return (
+                      <Typography
+                        key={
+                          idx
+                        }>{`[ ${accidentItem.accidentType} ] ${accidentItem.accidentDesc} ( ${accidentItem.accidentDate} )`}</Typography>
+                    );
+                  })}
+                </Grid>
+                <Grid item xs={12} py={2}>
+                  <Typography variant="h6" fontWeight="bold">
+                    교체이력 조회
+                  </Typography>
+                  {approveSaleForm.carExchangeInfoDtoList.map((exchangeItem, idx) => {
+                    return (
+                      <Typography
+                        key={
+                          idx
+                        }>{`[ ${exchangeItem.exchangeType} ] ${exchangeItem.exchangeDesc} ( ${exchangeItem.exchangeDate} )`}</Typography>
+                    );
+                  })}
+                </Grid>
+              </Card>
             </Grid>
           </Grid>
-        </Container>
-        {showModal && (
-          <OneButtonModal
-            onClickModal={handleClickModal}
-            isOpen={showModal}
-            modalContent={ADMIN_APPROVE_MODAL.CONTENTS}
-            callBackFunc={handleSubmit}
-          />
-        )}
-      </ThemeProvider>
-    )
+        </Grid>
+      </Container>
+      {showModal && (
+        <OneButtonModal
+          onClickModal={handleClickModal}
+          isOpen={showModal}
+          modalContent={ADMIN_APPROVE_MODAL.CONTENTS}
+          callBackFunc={handleSubmit}
+        />
+      )}
+    </ThemeProvider>
+  ) : (
+    <>
+      {/* TODO: 데이터 로딩 component 보여주기 */}
+      <Typography>데이터 로딩중...</Typography>
+    </>
   );
 }
 

--- a/frontend/src/pages/admin/sales/index.js
+++ b/frontend/src/pages/admin/sales/index.js
@@ -3,14 +3,15 @@ import AdminPageLayout from '@/layouts/admin/AdminPageLayout';
 import { CssBaseline, ThemeProvider, Typography, responsiveFontSizes } from '@mui/material';
 import theme from '@/styles/theme';
 import withAdminAuth from '@/hooks/withAdminAuth';
-import { useRouter } from 'next/router';
 import { ADMIN_DENY_MODAL } from '@/constants/string';
 import SaleTable from '@/components/admin/SaleTable';
 import BasicModal from '@/components/common/BasicModal';
+import { allSaleFormGetApi, denySaleFormPatchApi } from '@/services/adminpageApi';
 
 function AdminSalesList() {
   const [mounted, setMounted] = useState(false);
-  const router = useRouter();
+  const [allSaleFormInfo, setAllSaleFormInfo] = useState();
+  const [currentSaleFormId, setCurrentSaleFormId] = useState();
   let responsiveFontTheme = responsiveFontSizes(theme);
 
   // Modal 버튼 클릭 유무
@@ -18,16 +19,21 @@ function AdminSalesList() {
   const handleClickModal = () => setShowModal(!showModal);
 
   /**
-   * 수정 form 제출
+   * 판매 신청 form 반려하기
    */
   const handleDeny = async () => {
-    try {
-      // await adminDeleteProduct(memberId, productId, updateData);
-      alert('반려 완료');
-      router.push(`/admin/sales`);
-    } catch (error) {
-      console.log('실패');
-    }
+    console.log('반려');
+    console.log(currentSaleFormId);
+    // try {
+    //   await denySaleFormPatchApi(currentSaleFormId).then((res) => {
+    //     if (res.status === 200) {
+    //       alert('반려 완료');
+    //       router.push(`/admin/sales`);
+    //     }
+    //   });
+    // } catch (error) {
+    //   console.log('실패');
+    // }
   };
 
   const mypageCss = {
@@ -41,63 +47,36 @@ function AdminSalesList() {
   const table_cell_data = [
     {
       headerLabel: '판매요청자',
-      contentCell: 'seller',
+      contentCell: 'name',
     },
     {
       headerLabel: '차량번호',
       contentCell: 'carNum',
     },
     {
-      headerLabel: '차고지',
-      contentCell: 'branch',
-    },
-    {
       headerLabel: '상태',
       contentCell: 'status',
     },
     {
-      headerLabel: '등록여부',
-      contentCell: 'isApproved',
+      headerLabel: '심사',
+      contentCell: 'saleConfirm',
     },
   ];
 
-  // TODO: axios로 data 받아온 데이터라고 가정
-  const dummy_content_data = {
-    content: [
-      {
-        id: 1,
-        seller: '홍속초',
-        carNum: '11가1234',
-        branch: '서울',
-        status: '상태내용',
-        isApproved: 1,
-      },
-      {
-        id: 2,
-        seller: '김속초',
-        carNum: '11가1234',
-        branch: '서울',
-        status: '상태내용',
-        isApproved: 0,
-      },
-      {
-        id: 3,
-        seller: '박속초',
-        carNum: '11가1234',
-        branch: '서울',
-        status: '상태내용',
-        isApproved: 1,
-      },
-    ],
-  };
-
-  // data 불러온 이후 필터링 data에 맞게 렌더링
+  /**
+   * 전체 saleform의 정보를 GET
+   */
   useEffect(() => {
+    allSaleFormGetApi().then((data) => {
+      console.log(data);
+      setAllSaleFormInfo(data);
+    });
     setMounted(true);
   }, []);
 
   return (
-    mounted && (
+    mounted &&
+    allSaleFormInfo && (
       <ThemeProvider theme={responsiveFontTheme}>
         <CssBaseline />
         <Typography sx={mypageCss.mypageTitle} component="h4" variant="h4" gutterBottom>
@@ -105,9 +84,10 @@ function AdminSalesList() {
         </Typography>
         <SaleTable
           headerData={table_cell_data}
-          contentData={dummy_content_data.content}
+          contentData={allSaleFormInfo.content}
           moveUrl={`/admin/sales/approve/`}
           callbackFunc={handleClickModal}
+          setCurrentSaleFormId={setCurrentSaleFormId}
         />
         {showModal && (
           <BasicModal

--- a/frontend/src/services/adminpageApi.js
+++ b/frontend/src/services/adminpageApi.js
@@ -111,3 +111,87 @@ export const deleteProductApplicationsPatchApi = async (productId) => {
     throw error;
   }
 };
+
+/**
+ * [관리자 - sale] 판매 신청 관리 목록 전체 조회 (GET)
+ */
+export const allSaleFormGetApi = async () => {
+  try {
+    const response = await authInstance.get(`admin/sales`);
+    const data = response.data;
+    return data;
+  } catch (error) {
+    console.log('실패 : ', error);
+    throw error;
+  }
+};
+
+/**
+ * [관리자 - sale] 판매 신청 폼 반려하기 (PATCH)
+ */
+export const denySaleFormPatchApi = async (saleFormId) => {
+  try {
+    const response = await authInstance.patch(`admin/sales/deny/${saleFormId}`);
+    return response;
+  } catch (error) {
+    console.log('실패 : ', error);
+    throw error;
+  }
+};
+
+/**
+ * [관리자 - sale] 점검차량 정보 입력 (GET)
+ */
+export const oneApproveFormGetApi = async (saleFormId) => {
+  try {
+    const response = await authInstance.get(`admin/sales/approve/${saleFormId}`);
+    return response;
+  } catch (error) {
+    console.log('실패 : ', error);
+    throw error;
+  }
+};
+
+/**
+ * [관리자 - sale] 점검차량 정보 입력 후, patch 요청 (PATCH)
+ */
+export const oneApproveFormPatchApi = async (saleFormId) => {
+  try {
+    const response = await authInstance.get(`admin/sales/approve/${saleFormId}`);
+    return response;
+  } catch (error) {
+    console.log('실패 : ', error);
+    throw error;
+  }
+};
+
+/**
+ * [관리자 - sale] 차량 게시글 등록을 위한 폼 데이터를 QLDB에서 조회 (GET)
+ */
+export const oneRegisterFormGetApi = async (saleFormId) => {
+  try {
+    const response = await authInstance.get(`admin/sales/register/${saleFormId}`);
+    const data = response.data;
+    return data;
+  } catch (error) {
+    console.log('실패 : ', error);
+    throw error;
+  }
+};
+
+/**
+ * [관리자 - sale] 차량 게시글을 등록 (POST)
+ */
+export const oneRegisterFormPostApi = async (saleFormId, registerInputForm) => {
+  try {
+    const response = await authInstance.post(
+      `admin/sales/register/${saleFormId}`,
+      registerInputForm,
+    );
+    const data = response.data;
+    return data;
+  } catch (error) {
+    console.log('실패 : ', error);
+    throw error;
+  }
+};


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- 관리자페이지의 판매 신청 관리 목록, 판매 승인, 판매 게시글 등록 API 연동

## 관련 이슈

- #191 
## 세부 작업 내용

- [x] 판매 신청 관리 목록 조회
- [x] 판매 승인 요청 목록 상세 조회
- [ ] 판매 승인 반려
- [ ] 판매 승인 요청하기
- [ ] 판매 게시글 보여주기
- [ ] 판매 게시글 등록

## 참고 사항

- 백엔드 작업 이후에 다시 API 연동 작업하겠습니다!
