### PR TITLE
[chore] 프론트에서 api 요청 중 필요한 기능 추가 수정

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/admin/controller/ApproveSaleController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/controller/ApproveSaleController.java
@@ -34,7 +34,13 @@ public class ApproveSaleController {
     @GetMapping
     public ResponseEntity<Page<ApproveSaleResponseDto>> allSaleForms(Pageable pageable) {
         List<ApproveSaleResponseDto> saleForms = approveSaleService.getApproveSaleForm(pageable).getResults();
-        return ResponseEntity.ok(new PageImpl<>(saleForms, pageable, saleForms.size()));
+        Long size =  approveSaleService.getApproveSaleForm(pageable).getTotal();
+        return ResponseEntity.ok(new PageImpl<>(saleForms, pageable, size));
+    }
+
+    @PatchMapping("/deny/{saleFormId}")
+    public ResponseEntity<Boolean> denySaleForm(@RequestParam Long saleFormId){
+        return ResponseEntity.ok(approveSaleService.updateSaleFormDenyStatus(saleFormId));
     }
 
     // 점검 후 해당 saleform에 해당하는 car의 정보와 distance,car accident, car exchange를 조회한다.

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/controller/ManageMemberController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/controller/ManageMemberController.java
@@ -25,7 +25,8 @@ public class ManageMemberController {
     @GetMapping
     public ResponseEntity<Page<MemberInfoListResponseDto>> getMemberInfoList(Pageable pageable){
         List<MemberInfoListResponseDto> memberInfo = manageMemberService.getAllMemberInfo(pageable).getResults();
-        return ResponseEntity.ok(new PageImpl<>(memberInfo, pageable, memberInfo.size()));
+        Long size = manageMemberService.getAllMemberInfo(pageable).getTotal();
+        return ResponseEntity.ok(new PageImpl<>(memberInfo, pageable, size));
     }
 
     @GetMapping("/{memberId}")

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CarInspectionInfoResponseDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CarInspectionInfoResponseDto.java
@@ -1,5 +1,6 @@
 package com.woochacha.backend.domain.admin.dto.approve;
 
+import com.woochacha.backend.domain.car.info.entity.ExchangeType;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -15,4 +16,5 @@ public class CarInspectionInfoResponseDto {
     private int carDistance;
     private List<CarAccidentInfoDto> carAccidentInfoDtoList;
     private List<CarExchangeInfoDto> carExchangeInfoDtoList;
+    private List<ExchangeType> exchangeTypeList;
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/service/ApproveSaleService.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/service/ApproveSaleService.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface ApproveSaleService {
     QueryResults<ApproveSaleResponseDto> getApproveSaleForm(Pageable pageable);
+    Boolean updateSaleFormDenyStatus(Long saleFormId);
     CarInspectionInfoResponseDto getQldbCarInfoList(String carNum, String accidentMetaId, String exchangeMetaId);
     int getCarDistance(String carNum);
     void updateSaleFormStatus(Long saleFormId);

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/service/impl/ApproveSaleServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/service/impl/ApproveSaleServiceImpl.java
@@ -11,6 +11,8 @@ import com.woochacha.backend.domain.admin.dto.approve.CarAccidentInfoDto;
 import com.woochacha.backend.domain.admin.dto.approve.CarExchangeInfoDto;
 import com.woochacha.backend.domain.admin.dto.approve.CarInspectionInfoResponseDto;
 import com.woochacha.backend.domain.admin.service.ApproveSaleService;
+import com.woochacha.backend.domain.car.info.entity.ExchangeType;
+import com.woochacha.backend.domain.car.info.repository.ExchangeTypeRepository;
 import com.woochacha.backend.domain.sale.entity.QSaleForm;
 import com.woochacha.backend.domain.sale.entity.SaleForm;
 import com.woochacha.backend.domain.sale.repository.SaleFormRepository;
@@ -36,6 +38,7 @@ public class ApproveSaleServiceImpl implements ApproveSaleService {
     private CarInspectionInfoResponseDto carInspectionInfoResponseDto;
     private int carDistance;
     private final SaleFormRepository saleFormRepository;
+    private final ExchangeTypeRepository exchangeTypeRepository;
 
     @Override
     public QueryResults<ApproveSaleResponseDto> getApproveSaleForm(Pageable pageable) {
@@ -53,6 +56,16 @@ public class ApproveSaleServiceImpl implements ApproveSaleService {
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetchResults();
+    }
+
+    @Override
+    @Transactional
+    public Boolean updateSaleFormDenyStatus(Long saleFormId){
+        int count = saleFormRepository.updateDenyStatus(saleFormId);
+        if(count != 0){
+            return true;
+        }
+        return false;
     }
 
     // qldb에서 차량 번호에 따른 필요한 차량 정보를 가지고 온다.
@@ -93,6 +106,7 @@ public class ApproveSaleServiceImpl implements ApproveSaleService {
                 Result resultCarInfo = txn.execute(
                         "SELECT r.car_owner_name, r.car_owner_phone, r.car_distance FROM car AS r WHERE r.car_num=?", ionSys.newString(carNum));
                 IonStruct ionStruct = (IonStruct) resultCarInfo.iterator().next();
+                List<ExchangeType> exchangeTypeList = exchangeTypeRepository.findAll();
                 carInspectionInfoResponseDto = CarInspectionInfoResponseDto.builder()
                         .carNum(carNum)
                         .carOwnerName(((IonString) ionStruct.get("car_owner_name")).stringValue())
@@ -100,6 +114,7 @@ public class ApproveSaleServiceImpl implements ApproveSaleService {
                         .carDistance(((IonInt) ionStruct.get("car_distance")).intValue())
                         .carAccidentInfoDtoList(accidentInfoDtoList)
                         .carExchangeInfoDtoList(exchangeInfoDtoList)
+                        .exchangeTypeList(exchangeTypeList)
                         .build();
             });
             return carInspectionInfoResponseDto;

--- a/backend/src/main/java/com/woochacha/backend/domain/sale/controller/SaleController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/sale/controller/SaleController.java
@@ -16,8 +16,6 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/products/sale")
 public class SaleController {
-    private final MemberRepository memberRepository;
-    private final BranchRepository branchRepository;
     private final SaleFormApplyService saleFormApplyService;
 
     @GetMapping

--- a/backend/src/main/java/com/woochacha/backend/domain/sale/repository/SaleFormRepository.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/sale/repository/SaleFormRepository.java
@@ -13,6 +13,10 @@ public interface SaleFormRepository extends JpaRepository<SaleForm, Long> {
     @Query("UPDATE SaleForm AS sf SET sf.carStatus = 3 WHERE sf.id = :saleFormId")
     void updateStatus(@Param("saleFormId") Long saleFormId);
 
+    @Modifying
+    @Query("UPDATE SaleForm AS sf SET sf.carStatus = 1 WHERE sf.id = :saleFormId")
+    int updateDenyStatus(@Param("saleFormId") Long saleFormId);
+
     @Query("SELECT COUNT(*) FROM SaleForm sf WHERE sf.member.id = :memberId AND sf.carStatus.id = :carStatusId")
     int countSale(@Param("memberId") Long memberId, @Param("carStatusId") short carStatusId);
 


### PR DESCRIPTION

## 구현 기능

- 프론트에서 api 요청을 할 때 필요한 데이터에 대해서 추가합니다

## 관련 이슈

- Close #193 

## 세부 작업 내용

- [x] 판매 신청 승인한 폼에 대해서 반려하는 기능 추가
- [x] 관리자 페이지에서 차량 점검 작성할 때, Get 요청으로 교체 부위 종류 넘겨주기(id도 함께)
- [x] pageble에 totalpage잘 넘어가게 수

## 참고 사항

- 반려 기능을 하면 db의 saleForm의 status가 1로 바뀝니다.
![image](https://github.com/woorifisa-projects/woochacha/assets/87774238/3fa50b5d-f4e3-4445-afd4-ba93d0ce507d)

- 점검 후 새로운 차량 정보를 입력하려고 할 때 차량 정보 불러옴과 동시에 교체이력 종류도 함께 불러옵니다(ExchangeTypeList)
![image](https://github.com/woorifisa-projects/woochacha/assets/87774238/0f0405db-1ba7-41d7-b50a-59f5afbe0f11)

- total페이지와 total item의 갯수가 나오게 수정
![image](https://github.com/woorifisa-projects/woochacha/assets/87774238/002eb688-8312-4a24-9ab3-67dd0ffff6cf)

