### PR TITLE
[feat] 판매 신청 폼의 api 요청 구현

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/manageMember/PurchaseFormListResponseDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/manageMember/PurchaseFormListResponseDto.java
@@ -7,16 +7,16 @@ import lombok.Getter;
 @Builder
 public class PurchaseFormListResponseDto {
     private Long productId;
-    private String productUrl;
+    private Long purchaseId;
     private String carNum;
     private String buyerName;
     private String sellerName;
     private int purchaseStatus;
     private int transactionStatus;
 
-    public PurchaseFormListResponseDto(Long productId, String productUrl, String carNum, String buyerName, String sellerName, int purchaseStatus, int transactionStatus) {
+    public PurchaseFormListResponseDto(Long productId, Long purchaseId, String carNum, String buyerName, String sellerName, int purchaseStatus, int transactionStatus) {
         this.productId = productId;
-        this.productUrl = productUrl;
+        this.purchaseId = purchaseId;
         this.carNum = carNum;
         this.buyerName = buyerName;
         this.sellerName = sellerName;

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/service/impl/ManageTransactionServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/service/impl/ManageTransactionServiceImpl.java
@@ -72,7 +72,7 @@ public class ManageTransactionServiceImpl implements ManageTransactionService {
             }
             PurchaseFormListResponseDto dto = PurchaseFormListResponseDto.builder()
                     .productId((Long) data[0])
-                    .productUrl("http://localhost:8080/products/detail/" + data[0])
+                    .purchaseId((Long) data[5])
                     .carNum((String) data[1])
                     .buyerName((String) data[2])
                     .sellerName((String) data[3])

--- a/backend/src/main/java/com/woochacha/backend/domain/product/repository/ProductRepository.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/repository/ProductRepository.java
@@ -17,5 +17,10 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             "JOIN p.saleForm sf " +
             "WHERE p.saleForm.member.id = :memberId AND p.status.id = :carStatusId")
     int countSale(@Param("memberId") Long memberId, @Param("carStatusId") short carStatusId);
+
+    @Query("SELECT COUNT(*) FROM Product p " +
+            "JOIN p.carDetail cd " +
+            "WHERE p.carDetail.carNum = :carNum AND p.status.id = :status")
+    int checkCarNum(@Param("carNum") String carNum, @Param("status") short status);
 }
 

--- a/backend/src/main/java/com/woochacha/backend/domain/sale/controller/SaleController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/sale/controller/SaleController.java
@@ -25,19 +25,12 @@ public class SaleController {
     }
 
     @PostMapping
-    public ResponseEntity<Boolean> submitCarSaleForm(@RequestBody SaleFormRequestDto requestDto) {
+    public ResponseEntity<String> submitCarSaleForm(@RequestBody SaleFormRequestDto requestDto) {
         String carNum = requestDto.getCarNum();
         Long memberId = requestDto.getMemberId();
         Long branchId = requestDto.getBranchId();
-
-        Boolean match = saleFormApplyService.submitCarSaleForm(carNum, memberId);
-
-        if(match){
-            saleFormApplyService.saveSaleForm(carNum, memberId, branchId);
-            return ResponseEntity.ok(true);
-        }else{
-            return ResponseEntity.ok(false);
-        }
+        String match = saleFormApplyService.submitCarSaleForm(carNum, memberId, branchId);
+        return ResponseEntity.ok(match);
         // 둘 중 return 값으로 어떤 걸 사용할지 고민 중
         // return new ResponseEntity<>(saleForm, HttpStatus.CREATED);
     }

--- a/backend/src/main/java/com/woochacha/backend/domain/sale/service/SaleFormApplyService.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/sale/service/SaleFormApplyService.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface SaleFormApplyService {
     List<BranchDto> getBranchList();
-    Boolean submitCarSaleForm(String carNum, Long memberId);
+    String submitCarSaleForm(String carNum, Long memberId, Long branchId);
     String findCarNum(Long saleFormId);
     void saveSaleForm(String carNum, Long memberId, Long branchId);
 }

--- a/frontend/src/services/productApi.js
+++ b/frontend/src/services/productApi.js
@@ -1,4 +1,4 @@
-import { jsonInstance } from '@/utils/api';
+import { authInstance, jsonInstance } from '@/utils/api';
 
 export const allProductGetApi = async () => {
   try {
@@ -69,7 +69,7 @@ export const keywordProductGetApi = async (keyword) => {
   console.log(keyword);
   try {
     const response = await jsonInstance.get('/product/search', {
-      params: { keyword: keyword }
+      params: { keyword: keyword },
     });
     const data = response.data;
     return data;
@@ -79,3 +79,24 @@ export const keywordProductGetApi = async (keyword) => {
   }
 };
 
+export const getBranchApi = async () => {
+  try {
+    const response = await authInstance.get('/products/sale');
+    const data = response.data;
+    return data;
+  } catch (error) {
+    console.log('실패 : ', error);
+    throw error;
+  }
+};
+
+export const saleFormRequest = async (saleForm) => {
+  try {
+    const response = await authInstance.post('/products/sale', saleForm);
+    const data = response.data;
+    return data;
+  } catch (error) {
+    console.log('실패 : ', error);
+    throw error;
+  }
+};

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -2,8 +2,8 @@ import axios from 'axios';
 import LocalStorage from './localStorage';
 import { Router } from 'next/router';
 
-const BASE_URL = 'http://13.125.32.208:8080';
-// const BASE_URL = 'http://localhost:8080';
+// const BASE_URL = 'http://13.125.32.208:8080';
+const BASE_URL = 'http://localhost:8080';
 const HEADER_JSON = {
   headers: {
     'Content-Type': 'application/json',

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -2,8 +2,8 @@ import axios from 'axios';
 import LocalStorage from './localStorage';
 import { Router } from 'next/router';
 
-// const BASE_URL = 'http://13.125.32.208:8080';
-const BASE_URL = 'http://localhost:8080';
+const BASE_URL = 'http://13.125.32.208:8080';
+// const BASE_URL = 'http://localhost:8080';
 const HEADER_JSON = {
   headers: {
     'Content-Type': 'application/json',


### PR DESCRIPTION
## 구현 기능

- 판매 신청 폼의 api get과 post 요청 구현

## 관련 이슈

- Close #199 

## 세부 작업 내용

- [x] purchaseform을 조회할 때 url을 보내는 것이 아닌 product id와 purchase id를 전송하도록 수정. 
- [x] 차량 판매 신청폼에 따라 branch정보를 get요청으로 받아온다.
- [x] 차량 번호와 branch를 보내면 그에 따라 post 요청을 한다.
- [x] 받아온 response 값에 따라서 alert창을 보여준다.

## 참고 사항
![image](https://github.com/woorifisa-projects/woochacha/assets/87774238/47e08857-2aaa-4717-8934-18aafd86882b)

- 조건이 이렇게 들어가게 되고
- 프론트에서 차량 조회자체가 되지 않아 오류가 발생하면 "해당 차량은 없는 번호입니다"라고 alert로 보여줍니다.
