### PR TITLE
[Chore] 매물 로그 저장 수정&접속 권한 수정

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
@@ -140,14 +140,14 @@ public class MypageServiceImpl implements MypageService {
     @Transactional
     public void updatePrice(Long productId, Integer updatePrice, Long memberId){
         mypageRepository.updatePrice(productId, updatePrice);
-        logService.savedMemberLogWithTypeAndEtc(memberId, "상품 가격 수정 요청", "/product/" + productId);
+        logService.savedMemberLogWithTypeAndEtc(memberId, "상품 가격 수정 요청", "/product/detail/" + productId);
     }
 
     // 등록한 매물 삭제 신청
     @Transactional
     public void productDeleteRequest(Long productId, Long memberId){
         mypageRepository.requestProductDelete(productId);
-        logService.savedMemberLogWithTypeAndEtc(memberId, "상품 삭제 요청", "/product/" + productId);
+        logService.savedMemberLogWithTypeAndEtc(memberId, "상품 삭제 요청", "/product/detail/" + productId);
     }
 
     // 프로필 수정 (GET요청 시 데이터 보여주기)
@@ -168,7 +168,7 @@ public class MypageServiceImpl implements MypageService {
         String newProfileIamge = amazonS3Service.uploadProfile(amazonS3RequestDto);
         // TODO: multipartfile null 해결
 
-        logService.savedMemberLogWithTypeAndEtc(memberId, "프로필 이미지 수정", newProfileIamge);
+        logService.savedMemberLogWithType(memberId, "프로필 이미지 수정");
         return newProfileIamge;
     }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/product/service/impl/ProductServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/service/impl/ProductServiceImpl.java
@@ -340,7 +340,7 @@ public class ProductServiceImpl implements ProductService {
         Product product = productRepository.findById(productPurchaseRequestDto.getProductId()).orElseThrow(() -> new RuntimeException("SaleForm not found"));
         PurchaseForm purchaseForm = PurchaseForm.builder().member(member).product(product).build();
         purchaseFormRepository.save(purchaseForm);
-        logService.savedMemberLogWithTypeAndEtc(productPurchaseRequestDto.getMemberId(), "구매 신청", "/product/" + productPurchaseRequestDto.getProductId());
+        logService.savedMemberLogWithTypeAndEtc(productPurchaseRequestDto.getMemberId(), "구매 신청", "/product/detail/" + productPurchaseRequestDto.getProductId());
     }
 
     public List<ProductInfo> findSearchedProduct(String keyword) {

--- a/backend/src/main/java/com/woochacha/backend/domain/sale/service/SaleFormApplyServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/sale/service/SaleFormApplyServiceImpl.java
@@ -68,6 +68,7 @@ public class SaleFormApplyServiceImpl implements SaleFormApplyService{
         int checkCar = productRepository.checkCarNum(carNum, (short) 4);
         if(memberName.equals(owner) && memberPhone.equals(ownerPhone) && countAccident == 0 && checkCar == 0){
             saveSaleForm(carNum, memberId, branchId);
+            logService.savedMemberLogWithType(memberId, "판매 신청폼 제출");
             return "차량 판매 신청이 성공적으로 완료되었습니다.";
         } else if (!memberName.equals(owner)) {
             return "차량 소유주가 일치하지 않습니다.";
@@ -105,6 +106,5 @@ public class SaleFormApplyServiceImpl implements SaleFormApplyService{
                 .carStatus(carStatus)
                 .build();
         saleFormRepository.save(saleForm);
-        logService.savedMemberLogWithTypeAndEtc(memberId, "판매 신청폼 제출", "/admin/sales/approve/" + saleForm.getId());
     }
 }

--- a/backend/src/main/java/com/woochacha/backend/security/configs/SecurityConfig.java
+++ b/backend/src/main/java/com/woochacha/backend/security/configs/SecurityConfig.java
@@ -76,9 +76,10 @@ public class SecurityConfig {
 
                 .and() // TODO: 권한이 필요한 작업 전에 jwt principle과 email 비교해서 일치한 경우에만 진행되도록 리팩토링
                 .authorizeRequests()
-                .antMatchers("/users/**", "/products/sale", "/product/purchase", "/s3/upload-profile", "/mypage/**").hasRole("USER")
-                .antMatchers("/", "/users/register", "/users/login", "/product", "/product/**").permitAll()
-                .antMatchers("/admin/**", "/s3/**").hasRole("ADMIN")
+                .antMatchers("/", "/users/register", "/users/login", "/product").permitAll()
+                .antMatchers("/users/**", "/product/sale", "/product/purchase", "/mypage/**").hasRole("USER")
+                .antMatchers("/product/**").permitAll()
+                .antMatchers("/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated();
         return http.build();
     }

--- a/frontend/src/services/productApi.js
+++ b/frontend/src/services/productApi.js
@@ -56,7 +56,7 @@ export const productDetailGetApi = async (productId) => {
 export const purchaseRequest = async (purchaseForm) => {
   // userId,
   try {
-    const response = await jsonInstance.post(`/product/purchase`, purchaseForm);
+    const response = await authInstance.post(`/product/purchase`, purchaseForm);
     const data = response.data;
     return data;
   } catch (error) {


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- 매물 관련 로그 저장 시 etc 필드에 저장되는 매물 상세조회 url 수정
- Security Config 접속 권한 제어 경로 수정

## 관련 이슈

- Close #204

## 세부 작업 내용

- [ ] 상품 가격 수정 요청 시 저장되는 로그 etc 경로에 detail 추가
- [ ] 사용자 프로필 이미지 수정 시 etc 저장 기능 제거
- [ ] 사용자가 매물 구매 신청 시 저장되는 로그 etc 경로에 detail 추가
- [ ] 사용자가 판매 폼 신청 시 etc 저장 기능 제거
- [ ] SecurityConfig.java에서 회원 권한이 있을 시 "/product/sale", "/product/purchase" 경로 외 전체 "/product/**" 접근 권한 부여
- [ ] SecurityConfig.java에서 s3 관련 uri 제거
- [ ] 매물 구매 신청 폼 관련하여 jsonInstance -> authInstance로 수정

