### PR TITLE
[feat] db 이중화 구현

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/common/DataSourceType.java
+++ b/backend/src/main/java/com/woochacha/backend/common/DataSourceType.java
@@ -1,0 +1,5 @@
+package com.woochacha.backend.common;
+
+public enum DataSourceType {
+    MASTER, SLAVE
+}

--- a/backend/src/main/java/com/woochacha/backend/config/dataSourceReplication/DataSourceConfig.java
+++ b/backend/src/main/java/com/woochacha/backend/config/dataSourceReplication/DataSourceConfig.java
@@ -1,0 +1,37 @@
+package com.woochacha.backend.config.dataSourceReplication;
+
+import com.zaxxer.hikari.HikariDataSource;
+import javax.sql.DataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Slf4j
+@Configuration
+public class DataSourceConfig {
+
+    private final String MASTER_DATA_SOURCE = "masterDataSource";
+    private final String SLAVE_DATA_SOURCE = "slaveDataSource";
+
+    @Primary
+    @Bean(MASTER_DATA_SOURCE)
+    @ConfigurationProperties(prefix = "spring.datasource.master.hikari")
+    public DataSource masterDataSource() {
+        return DataSourceBuilder
+                .create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+    @Bean(SLAVE_DATA_SOURCE)
+    @ConfigurationProperties(prefix = "spring.datasource.slave.hikari")
+    public DataSource slaveDataSource() {
+        return DataSourceBuilder
+                .create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/woochacha/backend/config/dataSourceReplication/RoutingDataSource.java
+++ b/backend/src/main/java/com/woochacha/backend/config/dataSourceReplication/RoutingDataSource.java
@@ -1,0 +1,14 @@
+package com.woochacha.backend.config.dataSourceReplication;
+
+import com.woochacha.backend.common.DataSourceType;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class RoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        return TransactionSynchronizationManager.isCurrentTransactionReadOnly()
+                ? DataSourceType.SLAVE : DataSourceType.MASTER;
+    }
+}

--- a/backend/src/main/java/com/woochacha/backend/config/dataSourceReplication/RoutingDataSourceConfig.java
+++ b/backend/src/main/java/com/woochacha/backend/config/dataSourceReplication/RoutingDataSourceConfig.java
@@ -1,0 +1,82 @@
+package com.woochacha.backend.config.dataSourceReplication;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+
+import com.woochacha.backend.common.DataSourceType;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.JpaVendorAdapter;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@EnableJpaRepositories(
+        basePackages = "com.woochacha.backend.domain",
+        entityManagerFactoryRef = "entityManagerFactory",
+        transactionManagerRef = "transactionManager"
+)
+@Configuration
+public class RoutingDataSourceConfig {
+
+    private final String ROUTING_DATA_SOURCE = "routingDataSource";
+    private final String MASTER_DATA_SOURCE = "masterDataSource";
+    private final String SLAVE_DATA_SOURCE = "slaveDataSource";
+    private final String DATA_SOURCE = "dataSource";
+
+    @Bean(ROUTING_DATA_SOURCE)
+    public DataSource routingDataSource(
+            @Qualifier(MASTER_DATA_SOURCE) final DataSource masterDataSource,
+            @Qualifier(SLAVE_DATA_SOURCE) final DataSource slaveDataSource) {
+
+        RoutingDataSource routingDataSource = new RoutingDataSource();
+
+        Map<Object, Object> dataSourceMap = new HashMap<>();
+        dataSourceMap.put(DataSourceType.MASTER, masterDataSource);
+        dataSourceMap.put(DataSourceType.SLAVE, slaveDataSource);
+
+        routingDataSource.setTargetDataSources(dataSourceMap);
+        routingDataSource.setDefaultTargetDataSource(masterDataSource);
+
+        return routingDataSource;
+    }
+
+    @Bean(DATA_SOURCE)
+    public DataSource dataSource(
+            @Qualifier(ROUTING_DATA_SOURCE) DataSource routingDataSource) {
+        return new LazyConnectionDataSourceProxy(routingDataSource);
+    }
+
+    @Bean("entityManagerFactory")
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory(
+            @Qualifier(DATA_SOURCE) DataSource dataSource) {
+        LocalContainerEntityManagerFactoryBean entityManagerFactory
+                = new LocalContainerEntityManagerFactoryBean();
+        entityManagerFactory.setDataSource(dataSource);
+        entityManagerFactory.setPackagesToScan("com.woochacha.backend.domain");
+        entityManagerFactory.setJpaVendorAdapter(this.jpaVendorAdapter());
+        entityManagerFactory.setPersistenceUnitName("entityManager");
+        return entityManagerFactory;
+    }
+
+    private JpaVendorAdapter jpaVendorAdapter() {
+        HibernateJpaVendorAdapter hibernateJpaVendorAdapter = new HibernateJpaVendorAdapter();
+        hibernateJpaVendorAdapter.setGenerateDdl(false);
+        hibernateJpaVendorAdapter.setShowSql(false);
+        hibernateJpaVendorAdapter.setDatabasePlatform("org.hibernate.dialect.MySQL5InnoDBDialect");
+        return hibernateJpaVendorAdapter;
+    }
+
+    @Bean("transactionManager")
+    public PlatformTransactionManager platformTransactionManager(
+            @Qualifier("entityManagerFactory") LocalContainerEntityManagerFactoryBean entityManagerFactory) {
+        JpaTransactionManager jpaTransactionManager = new JpaTransactionManager();
+        jpaTransactionManager.setEntityManagerFactory(entityManagerFactory.getObject());
+        return jpaTransactionManager;
+    }
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/controller/ApproveSaleController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/controller/ApproveSaleController.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import java.io.IOException;
 import java.text.ParseException;
@@ -39,7 +40,7 @@ public class ApproveSaleController {
     }
 
     @PatchMapping("/deny/{saleFormId}")
-    public ResponseEntity<Boolean> denySaleForm(@RequestParam Long saleFormId){
+    public ResponseEntity<Boolean> denySaleForm(@PathVariable Long saleFormId){
         return ResponseEntity.ok(approveSaleService.updateSaleFormDenyStatus(saleFormId));
     }
 
@@ -55,6 +56,7 @@ public class ApproveSaleController {
 
     // 차량이 점검 후 입력한 값이 등록 조건에 맞으면 saleForm의 status를 변환시킨다.
     @PatchMapping("/approve/{saleFormId}")
+    @Transactional
     public ResponseEntity<Boolean> compareCarInfo(@RequestBody CompareRequestDto compareRequestDto, @PathVariable Long saleFormId){
         String carNum = saleFormApplyService.findCarNum(saleFormId);
         int carDistance = approveSaleService.getCarDistance(carNum);

--- a/backend/src/main/java/com/woochacha/backend/domain/car/detail/entity/CarDetail.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/detail/entity/CarDetail.java
@@ -23,18 +23,23 @@ public class CarDetail {
     private String carNum;
 
     @NotNull
+    @Column(name = "owner")
     private String owner;
 
     @NotNull
+    @Column(name = "phone")
     private String phone;
 
     @NotNull
+    @Column(name = "distance")
     private Integer distance;
 
     @NotNull
+    @Column(name = "year")
     private short year;
 
     @NotNull
+    @Column(name = "capacity")
     private short capacity;
 
     @OneToOne

--- a/backend/src/main/java/com/woochacha/backend/domain/car/detail/entity/CarName.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/detail/entity/CarName.java
@@ -16,6 +16,7 @@ public class CarName {
     private Long id;
 
     @NotNull
+    @Column(name = "name")
     private String name;
 
     public CarName(Long id, String name) {

--- a/backend/src/main/java/com/woochacha/backend/domain/car/detail/entity/CarOption.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/detail/entity/CarOption.java
@@ -23,27 +23,35 @@ public class CarOption {
     private CarDetail carDetail;
 
     @NotNull
+    @Column(name = "heated_seat")
     private Byte heatedSeat;
 
     @NotNull
+    @Column(name = "smart_key")
     private Byte smartKey;
 
     @NotNull
+    @Column(name = "blackbox")
     private Byte blackbox;
 
     @NotNull
+    @Column(name = "navigation")
     private Byte navigation;
 
     @NotNull
+    @Column(name = "airbag")
     private Byte airbag;
 
     @NotNull
+    @Column(name = "sunroof")
     private Byte sunroof;
 
     @NotNull
+    @Column(name = "high_pass")
     private Byte highPass;
 
     @NotNull
+    @Column(name = "rearview_camera")
     private Byte rearviewCamera;
 
     public CarOption(int id, CarDetail carDetail, Byte heatedSeat, Byte smartKey, Byte blackbox, Byte navigation, Byte airbag, Byte sunroof, Byte highPass, Byte rearviewCamera) {

--- a/backend/src/main/java/com/woochacha/backend/domain/car/info/entity/AccidentType.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/info/entity/AccidentType.java
@@ -16,5 +16,6 @@ public class AccidentType {
 
     @Enumerated(value = EnumType.STRING)
     @NotNull
+    @Column(name = "type")
     private AccidentTypeList type;
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/car/info/entity/CarAccidentInfo.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/info/entity/CarAccidentInfo.java
@@ -29,6 +29,7 @@ public class CarAccidentInfo {
 
     @CreationTimestamp
     @NotNull
+    @Column(name = "created_at")
     private Date createdAt;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/woochacha/backend/domain/car/info/entity/CarExchangeInfo.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/info/entity/CarExchangeInfo.java
@@ -28,6 +28,7 @@ public class CarExchangeInfo {
     private ExchangeType exchangeType;
 
     @CreationTimestamp
+    @Column(name = "created_at")
     private Date createdAt;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/woochacha/backend/domain/car/info/entity/ExchangeType.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/info/entity/ExchangeType.java
@@ -15,9 +15,6 @@ public class ExchangeType {
 
     @Enumerated(value = EnumType.STRING)
     @NotNull
+    @Column(name = "type")
     private ExchangeTypeList type;
-
-
-
-
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/car/type/entity/Color.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/type/entity/Color.java
@@ -16,5 +16,6 @@ public class Color {
 
     @Enumerated(value = EnumType.STRING)
     @NotNull
+    @Column(name = "name")
     private ColorList name;
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/car/type/entity/Fuel.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/type/entity/Fuel.java
@@ -15,5 +15,6 @@ public class Fuel {
 
     @Enumerated(value = EnumType.STRING)
     @NotNull
+    @Column(name = "name")
     private FuelList name;
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/car/type/entity/Model.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/type/entity/Model.java
@@ -20,6 +20,7 @@ public class Model {
 
     @Enumerated(value = EnumType.STRING)
     @NotNull
+    @Column(name = "name")
     private ModelList name;
 
     public Model(Integer id, ModelList name) {

--- a/backend/src/main/java/com/woochacha/backend/domain/car/type/entity/Transmission.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/type/entity/Transmission.java
@@ -15,5 +15,6 @@ public class Transmission {
 
     @Enumerated(value = EnumType.STRING)
     @NotNull
+    @Column(name = "name")
     private TransmissionList name;
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/car/type/entity/Type.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/car/type/entity/Type.java
@@ -15,5 +15,6 @@ public class Type {
 
     @Enumerated(value = EnumType.STRING)
     @NotNull
+    @Column(name = "name")
     private TypeList name;
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/log/entity/Log.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/log/entity/Log.java
@@ -26,17 +26,22 @@ public class Log {
     private Long id;
 
     @NotNull
+    @Column(name = "email")
     private String email;
 
     @NotNull
+    @Column(name = "name")
     private String name;
 
     @CreationTimestamp
+    @Column(name = "date")
     private LocalDateTime date;
 
     @NotNull
+    @Column(name = "type")
     private String type;
 
+    @Column(name = "etc")
     private String etc;
 
     public Log(Long id, String email, String name, String type, String etc) {

--- a/backend/src/main/java/com/woochacha/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/entity/Member.java
@@ -34,30 +34,39 @@ public class Member implements UserDetails {
     private Long id;
 
     @NotNull
+    @Column(name = "email")
     private String email;
 
     @NotNull
+    @Column(name = "password")
     private String password;
 
     @NotNull
+    @Column(name = "name")
     private String name;
 
     @NotNull
+    @Column(name = "phone")
     private String phone;
 
     @CreationTimestamp
+    @Column(name = "created_at")
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
     @ColumnDefault("1")
+    @Column(name = "is_available")
     private Byte isAvailable;
 
     @ColumnDefault("1")
+    @Column(name = "status")
     private Byte status;
 
     @NotNull
+    @Column(name = "profile_image")
     private String profileImage;
 
     @ElementCollection(fetch = FetchType.EAGER)

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/controller/MypageController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/controller/MypageController.java
@@ -88,7 +88,7 @@ public class MypageController {
     // 상품 수정 신청폼 제출
     @PatchMapping("/registered/edit")
     private ResponseEntity<String> editProductEditForm(@RequestParam("memberId") Long memberId, @RequestParam("productId") Long productId,
-                                                        @RequestBody @Valid UpdatePriceDto updatePriceDto){
+                                                      @RequestBody @Valid UpdatePriceDto updatePriceDto){
         EditProductDto editProductDto = mypageService.getProductEditRequestInfo(memberId, productId);
         if (updatePriceDto.getUpdatePrice() > editProductDto.getPrice()) {
             // TODO: 리팩토링 후, 이 부분 코드가 서비스 구현체로 들어가면 그때 "가격 변경 요청 실패" 로그 추가

--- a/backend/src/main/java/com/woochacha/backend/domain/product/entity/CarImage.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/entity/CarImage.java
@@ -25,9 +25,11 @@ public class CarImage {
     private Product product;
 
     @NotNull
+    @Column(name = "image_url")
     private String imageUrl;
 
     @CreationTimestamp
+    @Column(name = "created_at")
     private LocalDateTime createdAt;
 
     public CarImage() {

--- a/backend/src/main/java/com/woochacha/backend/domain/product/entity/Product.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/entity/Product.java
@@ -32,12 +32,15 @@ public class Product {
     private SaleForm saleForm;
 
     @NotNull
+    @Column(name = "price")
     private Integer price;
 
     @CreationTimestamp
+    @Column(name = "created_at")
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -48,6 +51,7 @@ public class Product {
     @JoinColumn(name = "car_num")
     private CarDetail carDetail;
 
+    @Column(name = "update_price")
     private Integer updatePrice;
 
     @OneToMany(mappedBy = "product") // carImage 엔티티와의 양방향 관계 설정

--- a/backend/src/main/java/com/woochacha/backend/domain/purchase/entity/PurchaseForm.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/purchase/entity/PurchaseForm.java
@@ -35,8 +35,10 @@ public class PurchaseForm {
     private Member member;
 
     @CreationTimestamp
+    @Column(name = "created_at")
     private LocalDateTime createdAt;
 
+    @Column(name = "meeting_date")
     private LocalDate meetingDate;
 
     @Column(name = "status")

--- a/backend/src/main/java/com/woochacha/backend/domain/sale/entity/Branch.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/sale/entity/Branch.java
@@ -15,5 +15,6 @@ public class Branch {
 
     @Enumerated(value = EnumType.STRING)
     @NotNull
+    @Column(name = "name")
     private BranchList name;
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/sale/entity/SaleForm.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/sale/entity/SaleForm.java
@@ -26,12 +26,15 @@ public class SaleForm {
     private Long id;
 
     @NotNull
+    @Column(name = "car_num")
     private String carNum;
 
     @CreationTimestamp
+    @Column(name = "created_at")
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/woochacha/backend/domain/status/entity/CarStatus.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/status/entity/CarStatus.java
@@ -15,5 +15,6 @@ public class CarStatus {
 
     @Enumerated(value = EnumType.STRING)
     @NotNull
+    @Column(name = "status")
     private CarStatusList status;
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/transaction/entity/Transaction.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/transaction/entity/Transaction.java
@@ -28,5 +28,6 @@ public class Transaction {
     private PurchaseForm purchaseForm;
 
     @CreationTimestamp
+    @Column(name = "created_at")
     private LocalDateTime createdAt;
 }


### PR DESCRIPTION

## 구현 기능

- db를 이중화하기 위한 구현을 진행한다.

## 관련 이슈

- Close #167 

## 세부 작업 내용

- [x] 각각의 entity에 column명을 지정
- [x] 읽기전용 db 복제본 생성
- [x] properties에 이중화된 db 설정
- [x] select와 insert(update,delete)가 중복으로 이루어질 시, transactional 어노테이션 추가

## 참고 사항

- 다음 페이지를 참고해서 코드를 작성하였습니다.
- https://tychejin.tistory.com/416
