### PR TITLE
[chore] @Builder 사용하는 DTO 생성자 작성

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/ApproveSaleResponseDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/ApproveSaleResponseDto.java
@@ -5,7 +5,7 @@ import lombok.*;
 
 @Getter
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class ApproveSaleResponseDto {
     //차량 승인을 위한 dto
     private Long id;

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/ApproveSaleResponseDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/ApproveSaleResponseDto.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ApproveSaleResponseDto {
     //차량 승인을 위한 dto
     private Long id;
@@ -12,14 +13,10 @@ public class ApproveSaleResponseDto {
     private String carNum;
     private CarStatusList status;
 
-    public ApproveSaleResponseDto() {
-    }
-
     public ApproveSaleResponseDto(Long id, String name, String carNum, CarStatusList status) {
         this.id = id;
         this.name = name;
         this.carNum = carNum;
         this.status = status;
-
     }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CarAccidentInfoDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CarAccidentInfoDto.java
@@ -4,7 +4,7 @@ import lombok.*;
 
 @Getter
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class CarAccidentInfoDto {
     // 사고이력 dto
     private String accidentType;

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CarAccidentInfoDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CarAccidentInfoDto.java
@@ -7,13 +7,15 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor
 public class CarAccidentInfoDto {
     // 사고이력 dto
     private String accidentType;
     private String accidentDesc;
     private String accidentDate;
 
-
+    public CarAccidentInfoDto(String accidentType, String accidentDesc, String accidentDate) {
+        this.accidentType = accidentType;
+        this.accidentDesc = accidentDesc;
+        this.accidentDate = accidentDate;
+    }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CarAccidentInfoDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CarAccidentInfoDto.java
@@ -1,17 +1,16 @@
 package com.woochacha.backend.domain.admin.dto.approve;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CarAccidentInfoDto {
     // 사고이력 dto
     private String accidentType;
     private String accidentDesc;
     private String accidentDate;
+
 
     public CarAccidentInfoDto(String accidentType, String accidentDesc, String accidentDate) {
         this.accidentType = accidentType;

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CarExchangeInfoDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CarExchangeInfoDto.java
@@ -7,11 +7,15 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor
 public class CarExchangeInfoDto {
     // 교체이력 dto
     private String exchangeType;
     private String exchangeDesc;
     private String exchangeDate;
+
+    public CarExchangeInfoDto(String exchangeType, String exchangeDesc, String exchangeDate) {
+        this.exchangeType = exchangeType;
+        this.exchangeDesc = exchangeDesc;
+        this.exchangeDate = exchangeDate;
+    }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CarExchangeInfoDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CarExchangeInfoDto.java
@@ -1,12 +1,10 @@
 package com.woochacha.backend.domain.admin.dto.approve;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CarExchangeInfoDto {
     // 교체이력 dto
     private String exchangeType;

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CarExchangeInfoDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CarExchangeInfoDto.java
@@ -4,7 +4,7 @@ import lombok.*;
 
 @Getter
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class CarExchangeInfoDto {
     // 교체이력 dto
     private String exchangeType;

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CarInspectionInfoResponseDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CarInspectionInfoResponseDto.java
@@ -17,4 +17,14 @@ public class CarInspectionInfoResponseDto {
     private List<CarAccidentInfoDto> carAccidentInfoDtoList;
     private List<CarExchangeInfoDto> carExchangeInfoDtoList;
     private List<ExchangeType> exchangeTypeList;
+
+    public CarInspectionInfoResponseDto(String carNum, String carOwnerName, String carOwnerPhone, int carDistance, List<CarAccidentInfoDto> carAccidentInfoDtoList, List<CarExchangeInfoDto> carExchangeInfoDtoList, List<ExchangeType> exchangeTypeList) {
+        this.carNum = carNum;
+        this.carOwnerName = carOwnerName;
+        this.carOwnerPhone = carOwnerPhone;
+        this.carDistance = carDistance;
+        this.carAccidentInfoDtoList = carAccidentInfoDtoList;
+        this.carExchangeInfoDtoList = carExchangeInfoDtoList;
+        this.exchangeTypeList = exchangeTypeList;
+    }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CarInspectionInfoResponseDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CarInspectionInfoResponseDto.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 @Getter
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class CarInspectionInfoResponseDto {
     // qldb에서 가지고 오는 모든 사고의 data를 저장하기 위한 dto
     private String carNum;

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CarInspectionInfoResponseDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CarInspectionInfoResponseDto.java
@@ -1,13 +1,16 @@
 package com.woochacha.backend.domain.admin.dto.approve;
 
 import com.woochacha.backend.domain.car.info.entity.ExchangeType;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CarInspectionInfoResponseDto {
     // qldb에서 가지고 오는 모든 사고의 data를 저장하기 위한 dto
     private String carNum;

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CompareRequestDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CompareRequestDto.java
@@ -5,7 +5,7 @@ import lombok.*;
 
 @Getter
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class CompareRequestDto {
     // 차량 검사 후 비교하여 교체된 이력에 대해 저장하는 dto
     private int distance;

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CompareRequestDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CompareRequestDto.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CompareRequestDto {
     // 차량 검사 후 비교하여 교체된 이력에 대해 저장하는 dto
     private int distance;

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CompareRequestDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/CompareRequestDto.java
@@ -5,12 +5,15 @@ import lombok.*;
 
 @Getter
 @Builder
-@AllArgsConstructor
 public class CompareRequestDto {
     // 차량 검사 후 비교하여 교체된 이력에 대해 저장하는 dto
     private int distance;
     private CarAccidentInfoDto carAccidentInfoDto;
     private CarExchangeInfoDto carExchangeInfoDto;
 
-    public CompareRequestDto() {}
+    public CompareRequestDto(int distance, CarAccidentInfoDto carAccidentInfoDto, CarExchangeInfoDto carExchangeInfoDto) {
+        this.distance = distance;
+        this.carAccidentInfoDto = carAccidentInfoDto;
+        this.carExchangeInfoDto = carExchangeInfoDto;
+    }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/RegisterProductDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/RegisterProductDto.java
@@ -4,13 +4,16 @@ package com.woochacha.backend.domain.admin.dto.approve;
 import com.woochacha.backend.domain.admin.dto.detail.RegisterProductBasicInfo;
 import com.woochacha.backend.domain.admin.dto.detail.RegisterProductDetailInfo;
 import com.woochacha.backend.domain.admin.dto.detail.RegisterProductOptionInfo;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RegisterProductDto {
 
     private RegisterProductBasicInfo registerProductBasicInfo; // 차량 기본 정보

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/RegisterProductDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/RegisterProductDto.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 @Getter
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class RegisterProductDto {
 
     private RegisterProductBasicInfo registerProductBasicInfo; // 차량 기본 정보

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/RegisterProductDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/approve/RegisterProductDto.java
@@ -18,4 +18,10 @@ public class RegisterProductDto {
     private RegisterProductDetailInfo registerProductDetailInfo; // 차량 상세 정보
 
     private List<RegisterProductOptionInfo> registerProductOptionInfos; // 옵션
+
+    public RegisterProductDto(RegisterProductBasicInfo registerProductBasicInfo, RegisterProductDetailInfo registerProductDetailInfo, List<RegisterProductOptionInfo> registerProductOptionInfos) {
+        this.registerProductBasicInfo = registerProductBasicInfo;
+        this.registerProductDetailInfo = registerProductDetailInfo;
+        this.registerProductOptionInfos = registerProductOptionInfos;
+    }
 }


### PR DESCRIPTION
## 구현 기능

- @Builder를 사용할 때 dto에서 생성자를 만들어주지 않은 경우가 많아 500에러가 발생해 생성자 작성

## 관련 이슈

- Close #224 

## 세부 작업 내용

- [x] 기존 allargscontructor 제거
- [x] builder 어노테이션을 사용하기 위한 생성자 작성

## 참고 사항

- @Builder를 DTO에서 사용할 경우 500에러가 발생하면 역직렬화에 대한 매핑 오류로 기본 생성자를 작성해주시기 바랍니다.(현재는 @NoArgsConstructor를 사용하시면 됩니다.) 

- @AllArgsContructor 사용하게 되면 모든 필드의 생성자를 모두 생성하기 때문에 순서가 바껴서 qldb에 들어가게되면 원장을 다시 생성해야합니다... (그리고 순서가 바뀌게되면 값이 순서가 바뀌어서 들어가서 나중에 오류 체크하기도 어렵습니다)

- 그리고 @NoArgsConstructor는 기본 생성자를 만들어주는데  access = AccessLevel.PROTECTED를 달아주면 의미 없는 객체 생성을 막아줘서 사용해도 괜찮지만 저희는 지금 QueryDSL을 사용해서 Qbean등록에 public만 접근이 가능해서 사용하지 않는 방향으로 가야할 것 같습니다. (@NoArgsConstructor를 사용하면 @Builder를 위한 전체 생성자를 만들어줘야합니다)

- 그럼에도 오류가 dto에서 생긴다면 builder를 전부 다 설정해서 build해주는지 확인 부탁드립니다.

- 대부분 기본 생성자가 필요할 때는 new를 통해서 dto를 새로 생성했을 때 입니다.


- 지양 이유에 대한 참고 사이트 입니다.
https://middleearth.tistory.com/5
- DTO에 기본 생성자를 사용하는 이유입니다.
https://ksh-coding.tistory.com/48
