### PR TITLE
[chore] "/product/{productId}" post 빌더 수정

### DIFF
--- a/backend/src/test/java/com/woochacha/backend/domain/product/controller/ProductControllerTest.java
+++ b/backend/src/test/java/com/woochacha/backend/domain/product/controller/ProductControllerTest.java
@@ -19,6 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.ArrayList;
@@ -32,8 +33,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -201,10 +201,10 @@ class ProductControllerTest extends CommonTest {
        Long productId = 14L;
        when(productService.findDetailProduct(productId)).thenReturn(productDetailResponseDto);
 
-       mockMvc.perform(get("/product/{productId}", productId))
+       mockMvc.perform(RestDocumentationRequestBuilders.get("/product/{productId}", productId))
                .andExpect(status().isOk())
                .andDo(document("product/get-detail",
-                       requestParameters(
+                       pathParameters(
                                parameterWithName("productId").description("매물 아이디")
                        ),
                        responseFields(


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- PathVailable이 사용되는 요청의 post 빌더 클래스 변경

## 관련 이슈

- Close #233

## 세부 작업 내용

- [x] PathVailable이 사용되는 요청의 경우 요청 시 빌더 클래스를 MockHttpServletRequestBuilder에서 RestDocumentationRequestBuilders로 변경


## 참고 사항

- Pathvailable이 사용되는 요청의 경우에는 아래와 같이 코드 작성하시면 됩니다.
``` java
mockMvc.perform(RestDocumentationRequestBuilders.get("/product/{productId}", productId))
               .andExpect(status().isOk())
               .andDo(document("product/get-detail",
                       pathParameters(
                               parameterWithName("productId").description("매물 아이디")
                       ),
...
```