### PR TITLE
[Feature] 로그인 한 회원의 토큰이 만료되었을 경우, 만료된 토큰이라는 메시지 전달

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/jwt/JwtAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/jwt/JwtAuthenticationEntryPoint.java
@@ -11,22 +11,30 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-/*
-    인증 처리 예외 핸들링
- */
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private String errorMessage;
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
-        sendErrorResponse(response, "Unauthorized");
+        sendErrorResponse(response, errorMessage);
     }
 
     private void sendErrorResponse(HttpServletResponse response, String message) throws IOException {
+        // TODO: org.springframework.web.util.NestedServletException: Request processing failed; nested exception is java.lang.IllegalStateException: getWriter() has already been called for this response 예외 해결
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.setContentType("application/json");
         LoginResponseDto errorResponse = new LoginResponseDto(HttpStatus.UNAUTHORIZED.value(), message);
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.writeValue(response.getWriter(), errorResponse);
     }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
 }
+/*
+    인증 처리 예외 핸들링
+ */
 

--- a/backend/src/main/java/com/woochacha/backend/domain/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/jwt/JwtAuthenticationFilter.java
@@ -34,14 +34,13 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             throws ServletException, IOException {
         try {
             String token = parseJwt((HttpServletRequest) request); // 헤더에서 토큰 추출
-            if (token != null && jwtTokenProvider.validateToken(token)) { // 토큰 유효성 검사
+            if (token != null && jwtTokenProvider.validateToken(token, request, response)) { // 토큰 유효성 검사
                 Authentication authentication = jwtTokenProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
         } catch (Exception e) {
             LOGGER.error("Cannot set user authentication: {}", e.getMessage());
         }
-
         filterChain.doFilter(request, response);
     }
 

--- a/backend/src/main/java/com/woochacha/backend/domain/jwt/JwtFilter.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/jwt/JwtFilter.java
@@ -31,7 +31,7 @@ public class JwtFilter extends GenericFilterBean {
         String requestURI = httpServletRequest.getRequestURI();
 
         // 토큰 유효성 검사
-        if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt)) {
+        if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt, request, response)) {
             Authentication authentication = jwtTokenProvider.getAuthentication(jwt);
             SecurityContextHolder.getContext().setAuthentication(authentication);
             LOGGER.debug("Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}", authentication.getName(), requestURI);


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- 처음부터 인증 권한이 없던 것이 아니라, 로그인을 한 회원이 토큰을 가지고 있지만, 해당 토큰이 만료된 경우 만료되었다는 메시지를 전달하도록 수정(이 메시지를 프론트에서 받아서 "로그인 유효 시간이 만료되었습니다. 다시 로그인 해주세요." 등의 alert를 띄운 후 로그인 페이지로 리다이렉트 되도록 추후 수정 예정)

## 관련 이슈

- Close #242

## 세부 작업 내용

- [x] 엔트리 포인트에 메시지 세팅 기능 추가
- [x] 토큰 유효성 검사 메서드에서 401 바디 전달 시 포함할 메시지 설정

## 참고 사항

- 아래와 같이 프론트에 전달됩니다.
![image](https://github.com/woorifisa-projects/woochacha/assets/93786956/b7db0092-1dca-402e-8a72-d98b14671401)

- 기타 토큰 유효성 관련 메시지는 JwtTokenProvider 클래스의 validateToken(token) 메서드를 확인해주세요.
- 배포 시에는 토큰 유효 시간을 30분으로 설정할 예정입니다.