### PR TITLE
[Bug] 차량 매물 등록시 사고, 교체이력 데이터 중복 해결

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/admin/service/impl/RegisterProductServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/service/impl/RegisterProductServiceImpl.java
@@ -124,10 +124,11 @@ public class RegisterProductServiceImpl implements RegisterProductService {
 
             // QLDB car_accident 테이블의 history 조회를 위한 metaId값 조회
             String metadataIdCarAccident = qldbService.getMetaIdValue(carNum, "car_accident");
-
+            System.out.println(metadataIdCarAccident);
             // QLDB car_accident 테이블의 history 조회
             Result resultCarAccident = txn.execute(
                     "SELECT ca.data.accident_type, ca.data.accident_date FROM history(car_accident) AS ca WHERE ca.metadata.id=?", ionSys.newString(metadataIdCarAccident));
+            registerProductAccidentInfos = new ArrayList<>();
             for (IonValue ionValue : resultCarAccident) {
                 IonStruct ionStruct = (IonStruct) ionValue;
 
@@ -145,6 +146,7 @@ public class RegisterProductServiceImpl implements RegisterProductService {
             LOGGER.info("Exchange"+metaIdCarExchange);
             LOGGER.info("Accident"+metadataIdCarAccident);
 
+            registerProductExchangeInfos = new ArrayList<>();
             // QLDB car_exchange 테이블의 history 조회
             Result resultCarExchange = txn.execute(
                     "SELECT ce.data.exchange_type, ce.data.exchange_date FROM history(car_exchange) AS ce WHERE ce.metadata.id=?", ionSys.newString(metaIdCarExchange));
@@ -331,5 +333,3 @@ public class RegisterProductServiceImpl implements RegisterProductService {
         }
     }
 }
-
-

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/service/impl/RegisterProductServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/service/impl/RegisterProductServiceImpl.java
@@ -124,7 +124,7 @@ public class RegisterProductServiceImpl implements RegisterProductService {
 
             // QLDB car_accident 테이블의 history 조회를 위한 metaId값 조회
             String metadataIdCarAccident = qldbService.getMetaIdValue(carNum, "car_accident");
-            System.out.println(metadataIdCarAccident);
+
             // QLDB car_accident 테이블의 history 조회
             Result resultCarAccident = txn.execute(
                     "SELECT ca.data.accident_type, ca.data.accident_date FROM history(car_accident) AS ca WHERE ca.metadata.id=?", ionSys.newString(metadataIdCarAccident));

--- a/backend/src/main/java/com/woochacha/backend/domain/product/service/impl/ProductServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/service/impl/ProductServiceImpl.java
@@ -192,7 +192,7 @@ public class ProductServiceImpl implements ProductService {
 
     private List<ProductAccidentInfo> getProductAccidentInfo(String carNum) {
         return queryFactory
-                .select(Projections.bean(ProductAccidentInfo.class,
+                .select(Projections.fields(ProductAccidentInfo.class,
                         at.type.stringValue().as("type"), at.type.count().intValue().as("count")))
                 .from(cd).join(ca).on(cd.carNum.eq(ca.carDetail.carNum))
                 .join(at).on(ca.accidentType.id.eq(at.id))


### PR DESCRIPTION
## 구현 기능
차량 매물 등록시 사고, 교체이력 데이터 중복 해결

## 관련 이슈

- Close #247 
## 세부 작업 내용

- [x] 차량 매물 등록시 사고, 교체이력 데이터 중복 해결

## 참고 사항

매물 등록할 때 교체, 사고이력 데이터가 중복되어서 나오는 부분 해결했습니다 !!