### PR TITLE
[Test] GET /admin/sales 리팩토링&테스트 코드 구현 및 Rest Docs 적용

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/admin/controller/ApproveSaleController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/controller/ApproveSaleController.java
@@ -1,24 +1,23 @@
 package com.woochacha.backend.domain.admin.controller;
 
+import com.woochacha.backend.domain.admin.dto.RegisterInputDto;
+import com.woochacha.backend.domain.admin.dto.RegisterProductDto;
 import com.woochacha.backend.domain.admin.dto.approve.ApproveSaleResponseDto;
 import com.woochacha.backend.domain.admin.dto.approve.CarInspectionInfoResponseDto;
 import com.woochacha.backend.domain.admin.dto.approve.CompareRequestDto;
-import com.woochacha.backend.domain.admin.dto.RegisterProductDto;
-import com.woochacha.backend.domain.admin.dto.*;
 import com.woochacha.backend.domain.admin.service.ApproveSaleService;
 import com.woochacha.backend.domain.admin.service.RegisterProductService;
 import com.woochacha.backend.domain.qldb.service.QldbService;
 import com.woochacha.backend.domain.sale.service.SaleFormApplyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
+
 import java.io.IOException;
 import java.text.ParseException;
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -34,9 +33,7 @@ public class ApproveSaleController {
     //관리자 페이지에서 모든 차량의 saleform 신청폼(점검 전)을 확인한다.
     @GetMapping
     public ResponseEntity<Page<ApproveSaleResponseDto>> allSaleForms(Pageable pageable) {
-        List<ApproveSaleResponseDto> saleForms = approveSaleService.getApproveSaleForm(pageable).getResults();
-        Long size =  approveSaleService.getApproveSaleForm(pageable).getTotal();
-        return ResponseEntity.ok(new PageImpl<>(saleForms, pageable, size));
+        return ResponseEntity.ok(approveSaleService.getApproveSaleForm(pageable));
     }
 
     @PatchMapping("/deny/{saleFormId}")

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/service/ApproveSaleService.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/service/ApproveSaleService.java
@@ -1,14 +1,14 @@
 package com.woochacha.backend.domain.admin.service;
 
-import com.querydsl.core.QueryResults;
 import com.woochacha.backend.domain.admin.dto.approve.ApproveSaleResponseDto;
 import com.woochacha.backend.domain.admin.dto.approve.CarAccidentInfoDto;
 import com.woochacha.backend.domain.admin.dto.approve.CarExchangeInfoDto;
 import com.woochacha.backend.domain.admin.dto.approve.CarInspectionInfoResponseDto;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ApproveSaleService {
-    QueryResults<ApproveSaleResponseDto> getApproveSaleForm(Pageable pageable);
+    Page<ApproveSaleResponseDto> getApproveSaleForm(Pageable pageable);
     Boolean updateSaleFormDenyStatus(Long saleFormId);
     CarInspectionInfoResponseDto getQldbCarInfoList(String carNum, String accidentMetaId, String exchangeMetaId);
     int getCarDistance(String carNum);

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/service/impl/ApproveSaleServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/service/impl/ApproveSaleServiceImpl.java
@@ -18,6 +18,8 @@ import com.woochacha.backend.domain.sale.entity.SaleForm;
 import com.woochacha.backend.domain.sale.repository.SaleFormRepository;
 import com.woochacha.backend.domain.status.entity.CarStatusList;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,10 +43,10 @@ public class ApproveSaleServiceImpl implements ApproveSaleService {
     private final ExchangeTypeRepository exchangeTypeRepository;
 
     @Override
-    public QueryResults<ApproveSaleResponseDto> getApproveSaleForm(Pageable pageable) {
+    public Page<ApproveSaleResponseDto> getApproveSaleForm(Pageable pageable) {
         QSaleForm sf = QSaleForm.saleForm;
 
-        return jpaQueryFactory
+        QueryResults<ApproveSaleResponseDto> approveSaleResponseDtoList = jpaQueryFactory
                 .select(Projections.fields(ApproveSaleResponseDto.class,
                         sf.id,
                         sf.member.name.as("name"),
@@ -57,6 +59,8 @@ public class ApproveSaleServiceImpl implements ApproveSaleService {
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetchResults();
+
+        return new PageImpl<>(approveSaleResponseDtoList.getResults());
     }
 
     @Override

--- a/backend/src/test/java/com/woochacha/backend/domain/admin/controller/ApproveSaleControllerTest.java
+++ b/backend/src/test/java/com/woochacha/backend/domain/admin/controller/ApproveSaleControllerTest.java
@@ -1,0 +1,130 @@
+package com.woochacha.backend.domain.admin.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.querydsl.core.QueryResults;
+import com.woochacha.backend.domain.admin.dto.approve.ApproveSaleResponseDto;
+import com.woochacha.backend.domain.admin.service.ApproveSaleService;
+import com.woochacha.backend.domain.common.CommonTest;
+import com.woochacha.backend.domain.status.entity.CarStatusList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ApproveSaleControllerTest extends CommonTest {
+    @InjectMocks
+    private ApproveSaleController approveSaleController;
+
+    @Mock
+    private ApproveSaleService approveSaleService;
+
+    @BeforeEach
+    public void init(RestDocumentationContextProvider restDocumentation) {
+        mockMvc = MockMvcBuilders.standaloneSetup(approveSaleController)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+                .apply(documentationConfiguration(restDocumentation)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint()))
+                .build();
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void allSaleForms() throws Exception {
+        ApproveSaleResponseDto approveSaleResponseDto = ApproveSaleResponseDto.builder()
+                .id(2L)
+                .name("주언반")
+                .carNum("74사4095")
+                .status(CarStatusList.심사중)
+                .build();
+        List<ApproveSaleResponseDto> result = new ArrayList<>();
+        result.add(approveSaleResponseDto);
+
+        QueryResults<ApproveSaleResponseDto> approveSaleResponseDtoList = new QueryResults<>(result, 5L, 0L, 10L);
+
+        Pageable pageable = PageRequest.of(0,5);
+
+        when(approveSaleService.getApproveSaleForm(any())).thenReturn(new PageImpl<>(approveSaleResponseDtoList.getResults()));
+
+        mockMvc.perform(get("/admin/sales")
+                        .param("pageable", String.valueOf(pageable))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andDo(document("admin/sales",
+                        requestParameters(
+                                parameterWithName("pageable").description("페이지네이션")
+                        ),
+                        responseFields(
+                                fieldWithPath("content[].id").description("saleform Id"),
+                                fieldWithPath("content[].name").description("판매 요청 회원 이름"),
+                                fieldWithPath("content[].carNum").description("판매 차량 번호"),
+                                fieldWithPath("content[].status").description("saleform의 현재 상태"),
+
+                                fieldWithPath("pageable").description("페이징 정보"),
+                                fieldWithPath("last").description("마지막 페이지 여부"),
+                                fieldWithPath("totalPages").description("총 페이지 수"),
+                                fieldWithPath("totalElements").description("총 요소 수"),
+                                fieldWithPath("size").description("페이지 크기"),
+                                fieldWithPath("number").description("현재 페이지 번호"),
+                                fieldWithPath("sort.empty").description("정렬 여부 (비어 있음)"),
+                                fieldWithPath("sort.sorted").description("정렬 여부 (정렬됨)"),
+                                fieldWithPath("sort.unsorted").description("정렬 여부 (정렬되지 않음)"),
+
+                                fieldWithPath("numberOfElements").description("현재 페이지의 요소 수"),
+                                fieldWithPath("first").description("첫 번째 페이지 여부"),
+                                fieldWithPath("empty").description("결과가 비어 있는지 여부")
+                        )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(approveSaleResponseDto.getId()))
+                .andExpect(jsonPath("$.content[0].name").value(approveSaleResponseDto.getName()))
+                .andExpect(jsonPath("$.content[0].carNum").value(approveSaleResponseDto.getCarNum()))
+                .andExpect(jsonPath("$.content[0].status").value(approveSaleResponseDto.getStatus().name()))
+                .andReturn();
+    }
+
+    @Test
+    void denySaleForm() {
+    }
+
+    @Test
+    void qldbCarInfo() {
+    }
+
+    @Test
+    void compareCarInfo() {
+    }
+
+    @Test
+    void registerProductInfo() {
+    }
+
+    @Test
+    void registerProduct() {
+    }
+}


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- GET /admin/sales 테스트 코드 구현 및 Rest Docs 적용
- 컨트롤러단의 서비스 로직을 서비스 구현체로 이전

## 관련 이슈

- Close #227

## 세부 작업 내용

- [x] GET /admin/sales 테스트 코드 구현 및 Rest Docs 적용
- [x] 컨트롤러단의 서비스 로직을 서비스 구현체로 이전 

