### PR TITLE
[Test] manage transaction 테스트 코드 작성&Rest Docs 적용

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -66,6 +66,7 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0'
 }
 
 // test 할 때 snippetsDir에 생성된 응답을 asciidoctor로 변환하여 .adoc 파일 생성

--- a/backend/src/docs/asciidoc/admin/ManageProduct.adoc
+++ b/backend/src/docs/asciidoc/admin/ManageProduct.adoc
@@ -10,60 +10,60 @@
 == 매물 관리
 === 수정/신청폼 조회
 ==== Http Request
-include::{snippets}/admin/get-product/http-request.adoc[]
+include::{snippets}/admin/product/get/http-request.adoc[]
 
 ==== Request Parameters
-include::{snippets}/admin/get-product/request-parameters.adoc[]
+include::{snippets}/admin/product/get/request-parameters.adoc[]
 
 ==== Http Response
-include::{snippets}/admin/get-product/http-response.adoc[]
+include::{snippets}/admin/product/get/http-response.adoc[]
 
 ==== Response Fields
-include::{snippets}/admin/get-product/response-fields.adoc[]
+include::{snippets}/admin/product/get/response-fields.adoc[]
 
 
 === 매물 삭제 신청 승인
 ==== Http Request
-include::{snippets}/admin/delete-product/http-request.adoc[]
+include::{snippets}/admin/product/delete/http-request.adoc[]
 
 ==== Path Parameters
-include::{snippets}/admin/delete-product/path-parameters.adoc[]
+include::{snippets}/admin/product/delete/path-parameters.adoc[]
 
 ==== Http Response
-include::{snippets}/admin/delete-product/http-response.adoc[]
+include::{snippets}/admin/product/delete/http-response.adoc[]
 
 
 === 매물 수정 전 매물 정보 조회
 ==== Http Request
-include::{snippets}/admin/get-edit-product/http-request.adoc[]
+include::{snippets}/admin/product/get-edit/http-request.adoc[]
 
 ==== Path Parameters
-include::{snippets}/admin/get-edit-product/path-parameters.adoc[]
+include::{snippets}/admin/product/get-edit/path-parameters.adoc[]
 
 ==== Http Response
-include::{snippets}/admin/get-edit-product/http-response.adoc[]
+include::{snippets}/admin/product/get-edit/http-response.adoc[]
 
 ==== Response Fields
-include::{snippets}/admin/get-edit-product/response-fields.adoc[]
+include::{snippets}/admin/product/get-edit/response-fields.adoc[]
 
 
 === 매물 가격 수정 반려
 ==== Http Request
-include::{snippets}/admin/deny-edit-product/http-request.adoc[]
+include::{snippets}/admin/product/deny-edit/http-request.adoc[]
 
 ==== Path Parameters
-include::{snippets}/admin/deny-edit-product/path-parameters.adoc[]
+include::{snippets}/admin/product/deny-edit/path-parameters.adoc[]
 
 ==== Http Response
-include::{snippets}/admin/deny-edit-product/http-response.adoc[]
+include::{snippets}/admin/product/deny-edit/http-response.adoc[]
 
 
 === 매물 가격 수정 승인
 ==== Http Request
-include::{snippets}/admin/approve-edit-product/http-request.adoc[]
+include::{snippets}/admin/product/approve-edit/http-request.adoc[]
 
 ==== Path Parameters
-include::{snippets}/admin/approve-edit-product/path-parameters.adoc[]
+include::{snippets}/admin/product/approve-edit/path-parameters.adoc[]
 
 ==== Http Response
-include::{snippets}/admin/approve-edit-product/http-response.adoc[]
+include::{snippets}/admin/product/approve-edit/http-response.adoc[]

--- a/backend/src/docs/asciidoc/admin/ManagePurchase.adoc
+++ b/backend/src/docs/asciidoc/admin/ManagePurchase.adoc
@@ -1,0 +1,58 @@
+:doctype: book
+:icons: font
+:toc: left
+:sectlinks:
+:sectnums:
+:docinfo: shared-head
+:toclevels: 2
+:source-highlighter: highlightjs
+
+== 거래 관리
+=== 구매 요청 목록 조회
+==== Http Request
+include::{snippets}/admin/purchase/get-form/http-request.adoc[]
+
+==== Request Parameters
+include::{snippets}/admin/purchase/get-form/request-parameters.adoc[]
+
+==== Http Response
+include::{snippets}/admin/purchase/get-form/http-response.adoc[]
+
+==== Response Fields
+include::{snippets}/admin/purchase/get-form/response-fields.adoc[]
+
+
+=== 매물 판매자, 구매 신청자 정보 조회
+==== Http Request
+include::{snippets}/admin/purchase/get-user/http-request.adoc[]
+
+==== Path Parameters
+include::{snippets}/admin/purchase/get-user/path-parameters.adoc[]
+
+==== Http Response
+include::{snippets}/admin/purchase/get-user/http-response.adoc[]
+
+==== Response Fields
+include::{snippets}/admin/purchase/get-user/response-fields.adoc[]
+
+
+=== 매물 거래일 지정
+==== Http Request
+include::{snippets}/admin/purchase/patch-date/http-request.adoc[]
+
+==== Path Parameters
+include::{snippets}/admin/purchase/patch-date/path-parameters.adoc[]
+
+==== Http Response
+include::{snippets}/admin/purchase/patch-date/http-response.adoc[]
+
+
+=== 성사된 거래 정보 저장
+==== Http Request
+include::{snippets}/admin/purchase/success/http-request.adoc[]
+
+==== Path Parameters
+include::{snippets}/admin/purchase/success/path-parameters.adoc[]
+
+==== Http Response
+include::{snippets}/admin/purchase/success/http-response.adoc[]

--- a/backend/src/docs/asciidoc/admin/Woochacha-admin.adoc
+++ b/backend/src/docs/asciidoc/admin/Woochacha-admin.adoc
@@ -10,3 +10,4 @@
 
 include::ManageProduct.adoc[]
 
+include::ManagePurchase.adoc[]

--- a/backend/src/main/java/com/woochacha/backend/domain/admin/dto/manageMember/PurchaseDateRequestDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/dto/manageMember/PurchaseDateRequestDto.java
@@ -9,4 +9,9 @@ import java.time.LocalDate;
 public class PurchaseDateRequestDto {
         @DateTimeFormat(pattern = "yyyy-MM-dd")
         private LocalDate meetingDate;
+
+        public PurchaseDateRequestDto() {}
+        public PurchaseDateRequestDto(LocalDate meetingDate) {
+                this.meetingDate = meetingDate;
+        }
 }

--- a/backend/src/test/java/com/woochacha/backend/domain/admin/controller/ManageProductControllerTest.java
+++ b/backend/src/test/java/com/woochacha/backend/domain/admin/controller/ManageProductControllerTest.java
@@ -65,11 +65,11 @@ class ManageProductControllerTest extends CommonTest {
         List<ManageProductFormDto> result = new ArrayList<>();
         result.add(manageProductFormDto);
 
-        QueryResults<ManageProductFormDto> purchaseFormListResponseDtoList = new QueryResults<>(result, 5L, 0L, 10L);
+        QueryResults<ManageProductFormDto> manageProductFormDtoQueryResults = new QueryResults<>(result, 5L, 0L, 10L);
 
         int page = 0, size = 5;
 
-        when(manageProductFormService.findDeleteEditForm(page, size)).thenReturn(new PageImpl<>(purchaseFormListResponseDtoList.getResults()));
+        when(manageProductFormService.findDeleteEditForm(page, size)).thenReturn(new PageImpl<>(manageProductFormDtoQueryResults.getResults()));
 
         mockMvc.perform(get("/admin/product")
                         .param("page", String.valueOf(page))
@@ -77,7 +77,7 @@ class ManageProductControllerTest extends CommonTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andDo(document("admin/get-product",
+                .andDo(document("admin/product/get",
                         requestParameters(
                                 parameterWithName("page").description("페이지 오프셋"),
                                 parameterWithName("size").description("페이지당 보여줄 매물 개수")
@@ -124,7 +124,7 @@ class ManageProductControllerTest extends CommonTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(new MediaType(MediaType.TEXT_PLAIN, StandardCharsets.UTF_8)))
                 .andDo(print())
-                .andDo(document("admin/delete-product",
+                .andDo(document("admin/product/delete",
                         pathParameters(
                                 parameterWithName("productId").description("삭제할 매물 아이디")
                         )))
@@ -150,7 +150,7 @@ class ManageProductControllerTest extends CommonTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andDo(document("admin/get-edit-product",
+                .andDo(document("admin/product/get-edit",
                         pathParameters(
                                 parameterWithName("productId").description("가격을 수정할 매물 아이디")
                         ),
@@ -180,7 +180,7 @@ class ManageProductControllerTest extends CommonTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(new MediaType(MediaType.TEXT_PLAIN, StandardCharsets.UTF_8)))
                 .andDo(print())
-                .andDo(document("admin/deny-edit-product",
+                .andDo(document("admin/product/deny-edit",
                         pathParameters(
                                 parameterWithName("productId").description("가격 수정을 반려할 매물 아이디")
                         )))
@@ -201,7 +201,7 @@ class ManageProductControllerTest extends CommonTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(new MediaType(MediaType.TEXT_PLAIN, StandardCharsets.UTF_8)))
                 .andDo(print())
-                .andDo(document("admin/approve-edit-product",
+                .andDo(document("admin/product/approve-edit",
                         pathParameters(
                                 parameterWithName("productId").description("가격 수정을 승인할 매물 아이디")
                         )))

--- a/backend/src/test/java/com/woochacha/backend/domain/admin/controller/ManageTransactionControllerTest.java
+++ b/backend/src/test/java/com/woochacha/backend/domain/admin/controller/ManageTransactionControllerTest.java
@@ -1,0 +1,207 @@
+package com.woochacha.backend.domain.admin.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.querydsl.core.QueryResults;
+import com.woochacha.backend.domain.admin.dto.manageMember.PurchaseDateRequestDto;
+import com.woochacha.backend.domain.admin.dto.manageMember.PurchaseFormListResponseDto;
+import com.woochacha.backend.domain.admin.dto.manageMember.PurchaseMemberInfoResponseDto;
+import com.woochacha.backend.domain.admin.service.ManageTransactionService;
+import com.woochacha.backend.domain.common.CommonTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class ManageTransactionControllerTest extends CommonTest {
+
+    @InjectMocks
+    private ManageTransactionController manageTransactionController;
+
+    @Mock
+    private ManageTransactionService manageTransactionService;
+
+    @BeforeEach
+    public void init(RestDocumentationContextProvider restDocumentation) {
+        mockMvc = MockMvcBuilders.standaloneSetup(manageTransactionController)
+                .apply(documentationConfiguration(restDocumentation)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint()))
+                .build();
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule()); // PurchaseDateRequestDto의 LocalDate 객체를 직렬화할 때 사용
+    }
+    @Test
+    @DisplayName("구매 요청 목록을 조회한다.")
+    void getAllPurchaseList() throws Exception {
+        PurchaseFormListResponseDto purchaseFormListResponseDto = PurchaseFormListResponseDto.builder()
+                .productId(1L)
+                .purchaseId(2L)
+                .carNum("22가 1111")
+                .buyerName("홍길동")
+                .sellerName("김철수")
+                .purchaseStatus(0)
+                .transactionStatus(1)
+                .build();
+        List<PurchaseFormListResponseDto> result = new ArrayList<>();
+        result.add(purchaseFormListResponseDto);
+
+        QueryResults<PurchaseFormListResponseDto> purchaseFormListResponseDtoList = new QueryResults<>(result, 5L, 0L, 10L);
+
+        int page = 0, size = 5;
+
+        Pageable pageable = PageRequest.of(page,size);
+        when(manageTransactionService.getAllPurchaseFormInfo(pageable)).thenReturn(new PageImpl<>(purchaseFormListResponseDtoList.getResults()));
+
+        mockMvc.perform(get("/admin/purchase")
+                        .param("page", String.valueOf(page))
+                        .param("size", String.valueOf(size))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andDo(document("admin/purchase/get-form",
+                        requestParameters(
+                                parameterWithName("page").description("페이지 오프셋"),
+                                parameterWithName("size").description("페이지당 보여줄 매물 개수")
+                        ),
+                        responseFields(
+                                fieldWithPath("content[].productId").description("판매글 아이디"),
+                                fieldWithPath("content[].purchaseId").description("구매 요청 아이디"),
+                                fieldWithPath("content[].carNum").description("차량 번호"),
+                                fieldWithPath("content[].buyerName").description("구매자 이름"),
+                                fieldWithPath("content[].sellerName").description("판매자 이름"),
+                                fieldWithPath("content[].purchaseStatus").description("구매 요청 상태"),
+                                fieldWithPath("content[].transactionStatus").description("거래 상태"),
+
+                                fieldWithPath("pageable").description("페이징 정보"),
+                                fieldWithPath("last").description("마지막 페이지 여부"),
+                                fieldWithPath("totalPages").description("총 페이지 수"),
+                                fieldWithPath("totalElements").description("총 요소 수"),
+                                fieldWithPath("size").description("페이지 크기"),
+                                fieldWithPath("number").description("현재 페이지 번호"),
+                                fieldWithPath("sort.empty").description("정렬 여부 (비어 있음)"),
+                                fieldWithPath("sort.sorted").description("정렬 여부 (정렬됨)"),
+                                fieldWithPath("sort.unsorted").description("정렬 여부 (정렬되지 않음)"),
+
+                                fieldWithPath("numberOfElements").description("현재 페이지의 요소 수"),
+                                fieldWithPath("first").description("첫 번째 페이지 여부"),
+                                fieldWithPath("empty").description("결과가 비어 있는지 여부")
+                        )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].productId").value(purchaseFormListResponseDto.getProductId()))
+                .andExpect(jsonPath("$.content[0].purchaseId").value(purchaseFormListResponseDto.getPurchaseId()))
+                .andExpect(jsonPath("$.content[0].carNum").value(purchaseFormListResponseDto.getCarNum()))
+                .andExpect(jsonPath("$.content[0].buyerName").value(purchaseFormListResponseDto.getBuyerName()))
+                .andExpect(jsonPath("$.content[0].sellerName").value(purchaseFormListResponseDto.getSellerName()))
+                .andExpect(jsonPath("$.content[0].purchaseStatus").value(purchaseFormListResponseDto.getPurchaseStatus()))
+                .andExpect(jsonPath("$.content[0].transactionStatus").value(purchaseFormListResponseDto.getTransactionStatus()))
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("구매 신청폼의 판매자, 구매자 정보를 조회한다.")
+    void matchPurchaseInfo() throws Exception {
+        PurchaseMemberInfoResponseDto purchaseMemberInfoResponseDto = PurchaseMemberInfoResponseDto.builder()
+                .sellerName("홍길동")
+                .sellerPhone("01055556666")
+                .buyerName("김철수")
+                .buyerPhone("01077778888")
+                .build();
+
+        Long purchaseId = 1L;
+
+        when(manageTransactionService.getPurchaseMemberInfo(purchaseId)).thenReturn(purchaseMemberInfoResponseDto);
+
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/admin/purchase/{purchaseId}", purchaseId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andDo(document("admin/purchase/get-user",
+                        pathParameters(
+                                parameterWithName("purchaseId").description("구매 요청 아이디")
+                        ),
+                        responseFields(
+                                fieldWithPath("sellerName").description("판매자 이름"),
+                                fieldWithPath("sellerPhone").description("판매자 핸드폰 번호"),
+                                fieldWithPath("buyerName").description("구매자 이름"),
+                                fieldWithPath("buyerPhone").description("구매자 핸드폰 번호")
+                        )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sellerName").value(purchaseMemberInfoResponseDto.getSellerName()))
+                .andExpect(jsonPath("$.sellerPhone").value(purchaseMemberInfoResponseDto.getSellerPhone()))
+                .andExpect(jsonPath("$.buyerName").value(purchaseMemberInfoResponseDto.getBuyerName()))
+                .andExpect(jsonPath("$.buyerPhone").value(purchaseMemberInfoResponseDto.getBuyerPhone()))
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("구매 신청폼에서 선택한 희망 거래일을 저장한다.")
+    void matchPurchaseDate() throws Exception {
+        PurchaseDateRequestDto purchaseDateRequestDto = new PurchaseDateRequestDto(LocalDate.now());
+        Long purchaseId = 1L;
+        String returnMessage = "날짜 매칭에 성공하였습니다.";
+
+        when(manageTransactionService.matchPurchaseDate(anyLong(), any(PurchaseDateRequestDto.class))).thenReturn(returnMessage);
+
+        mockMvc.perform(RestDocumentationRequestBuilders.patch("/admin/purchase/{purchaseId}", purchaseId)
+                        .content(objectMapper.writeValueAsString(purchaseDateRequestDto))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(new MediaType(MediaType.TEXT_PLAIN, StandardCharsets.UTF_8)))
+                .andDo(print())
+                .andDo(document("admin/purchase/patch-date",
+                        pathParameters(
+                                parameterWithName("purchaseId").description("구매 요청 아이디")
+                        )))
+                .andExpect(status().isOk())
+                .andExpect(content().string(returnMessage))
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("성사된 거래 정보를 저장한다.")
+    void insertTransaction() throws Exception {
+        Long purchaseId = 1L;
+        String returnMessage =  "거래가 성사되었습니다.";
+        
+        when(manageTransactionService.insertNewTransaction(purchaseId)).thenReturn(returnMessage);
+
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/admin/purchase/success/{purchaseId}", purchaseId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(new MediaType(MediaType.TEXT_PLAIN, StandardCharsets.UTF_8)))
+                .andDo(print())
+                .andDo(document("admin/purchase/success",
+                        pathParameters(
+                                parameterWithName("purchaseId").description("성사된 구매 요청 아이디")
+                        )))
+                .andExpect(status().isOk())
+                .andExpect(content().string(returnMessage))
+                .andReturn();
+    }
+}


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- ManageTransactionController테스트 코드 작성
- ManageTransactionController Rest Docs 적용

## 관련 이슈

- Close #259 

## 세부 작업 내용

- [x] ManageTransactionControllerTest.java 파일 생성 및 테스트 코드 구현
- [x] ManageTransaction.adoc에 Rest Docs 적용
- [x] PurchaseDateRequestDto의 LocalDate 객체를 직렬화하기 위해 jackson-datatype-jsr310 의존성 추가
- [x] PurchaseDateRequestDto에서 기본 생성자&전체 생성자 작성
- [x] 이전 ManageProductController의 Rest Docs 저장 경로를 /admin에서 /admin/product로 수정
