### PR TITLE
[Feature] 매물 필터링 검색, 키워드 검색 페이지네이션 적용

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/product/controller/ProductController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/controller/ProductController.java
@@ -6,10 +6,11 @@ import com.woochacha.backend.domain.product.dto.ProductPurchaseRequestDto;
 import com.woochacha.backend.domain.product.dto.all.ProductInfo;
 import com.woochacha.backend.domain.product.dto.filter.ProductFilterInfo;
 import com.woochacha.backend.domain.product.service.ProductService;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 @RestController
@@ -33,8 +34,8 @@ public class ProductController {
     }
 
     @PostMapping("/filter")
-    public List<ProductInfo> findFilteredProduct(@RequestBody ProductFilterInfo productFilterInfo) {
-        return productService.findFilteredProduct(productFilterInfo);
+    public PageImpl<ProductInfo> findFilteredProduct(@RequestBody ProductFilterInfo productFilterInfo, Pageable pageable) {
+        return productService.findFilteredProduct(productFilterInfo, pageable);
     }
 
     @PostMapping("/purchase")
@@ -44,7 +45,7 @@ public class ProductController {
     }
 
     @GetMapping("/search")
-    public List<ProductInfo> findSearchedProduct(@RequestParam(value="keyword") String keyword) {
-        return productService.findSearchedProduct(keyword);
+    public PageImpl<ProductInfo> findSearchedProduct(@RequestParam(value="keyword") String keyword, Pageable pageable) {
+        return productService.findSearchedProduct(keyword, pageable);
     }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/product/service/ProductService.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/service/ProductService.java
@@ -5,15 +5,14 @@ import com.woochacha.backend.domain.product.dto.ProductDetailResponseDto;
 import com.woochacha.backend.domain.product.dto.ProductPurchaseRequestDto;
 import com.woochacha.backend.domain.product.dto.all.ProductInfo;
 import com.woochacha.backend.domain.product.dto.filter.ProductFilterInfo;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-
-import java.util.List;
 
 public interface ProductService {
     ProductAllResponseDto findAllProduct(Pageable pageable);
     ProductDetailResponseDto findDetailProduct(Long productId);
-    List<ProductInfo> findFilteredProduct(ProductFilterInfo productFilterInfo);
+    PageImpl<ProductInfo> findFilteredProduct(ProductFilterInfo productFilterInfo, Pageable pageable);
     void applyPurchaseForm(ProductPurchaseRequestDto productPurchaseRequestDto);
 
-    List<ProductInfo> findSearchedProduct(String keyword);
+    PageImpl<ProductInfo> findSearchedProduct(String keyword, Pageable pageable);
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/product/service/impl/ProductServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/service/impl/ProductServiceImpl.java
@@ -170,8 +170,8 @@ public class ProductServiceImpl implements ProductService {
         return new ProductDetailResponseDto(basicInfo, productDetailInfo, productOptionInfo, productOwnerInfo, productImageList);
     }
 
-    private List<ProductInfo> findProductInfoList(BooleanExpression expression) {
-        return queryFactory
+    private PageImpl<ProductInfo> findProductDynamicInfoList(BooleanExpression expression, Pageable pageable) {
+        List<ProductInfo> productInfoList =  queryFactory
                 .select(Projections.fields(
                         ProductInfo.class, p.id,
                         Expressions.asString(
@@ -185,7 +185,11 @@ public class ProductServiceImpl implements ProductService {
                 .join(cn).on(cn.name.eq(cd.carName.name))
                 .where(p.status.id.eq((short) 4), ci.imageUrl.like("%/1").and(expression))
                 .orderBy(p.createdAt.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch();
+
+        return new PageImpl<>(productInfoList);
     }
 
     private ProductBasicInfo getProductBasicInfo(Long productId) {
@@ -276,8 +280,8 @@ public class ProductServiceImpl implements ProductService {
     }
 
     @Override
-    public List<ProductInfo> findFilteredProduct(ProductFilterInfo productFilterInfo) {
-        return findProductInfoList(dynamicSearch(productFilterInfo));
+    public PageImpl<ProductInfo> findFilteredProduct(ProductFilterInfo productFilterInfo, Pageable pageable) {
+        return findProductDynamicInfoList(dynamicSearch(productFilterInfo), pageable);
     }
 
     // 동적 where 조건절 쿼리 작성
@@ -366,13 +370,14 @@ public class ProductServiceImpl implements ProductService {
         logService.savedMemberLogWithTypeAndEtc(productPurchaseRequestDto.getMemberId(), "구매 신청", "/product/detail/" + productPurchaseRequestDto.getProductId());
     }
 
-    public List<ProductInfo> findSearchedProduct(String keyword) {
+    @Override
+    public PageImpl<ProductInfo> findSearchedProduct(String keyword, Pageable pageable) {
         BooleanExpression expression = dynamicSearchWholeModelKeyword(keyword); // 모델명 검색 동적 쿼리 생성
-        List<ProductInfo> keywordSearchedByModelName = findProductInfoList(expression); // 모델명 동적 쿼리 실행
+        PageImpl<ProductInfo> keywordSearchedByModelName = findProductDynamicInfoList(expression, pageable); // 모델명 동적 쿼리 실행
 
         // 모델명 검색 결과가 없으면 차량명 검색 동작
         if (keywordSearchedByModelName.isEmpty())
-            return findProductInfoList(dynamicSearchPartKeyword(keyword));
+            return findProductDynamicInfoList(dynamicSearchPartKeyword(keyword), pageable);
 
             // 모델명 검색 결과가 있다면 모델명 검색 결과 리턴
         else

--- a/backend/src/test/java/com/woochacha/backend/domain/product/controller/ProductControllerTest.java
+++ b/backend/src/test/java/com/woochacha/backend/domain/product/controller/ProductControllerTest.java
@@ -37,7 +37,6 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -301,9 +300,7 @@ class ProductControllerTest extends CommonTest {
        typeDtoList.add(typeDto);
        ProductFilterInfo productFilterInfo = ProductFilterInfo.builder()
                        .typeList(typeDtoList)
-                               .build();
-
-       System.out.println(productFilterInfo);
+                        .build();
 
        ProductInfo productInfo = ProductInfo.builder()
                .id((long) 14)
@@ -316,13 +313,23 @@ class ProductControllerTest extends CommonTest {
        List<ProductInfo> productInfoList = new ArrayList<>();
        productInfoList.add(productInfo);
 
-       when(productService.findFilteredProduct(any(ProductFilterInfo.class))).thenReturn(productInfoList);
+       PageImpl<ProductInfo> productInfoListPageable = new PageImpl<>(productInfoList);
+
+       Pageable pageable = PageRequest.of(0,5);
+
+       when(productService.findFilteredProduct(any(ProductFilterInfo.class), any())).thenReturn(productInfoListPageable);
 
        mockMvc.perform(post("/product/filter")
+                       .param("page", String.valueOf(pageable.getOffset()))
+                       .param("size", String.valueOf(pageable.getPageSize()))
                        .content(objectMapper.writeValueAsString(productFilterInfo))
                        .contentType(MediaType.APPLICATION_JSON))
                .andDo(print())
                .andDo(document("product/filter",
+                       requestParameters(
+                               parameterWithName("page").description("페이지 오프셋"),
+                               parameterWithName("size").description("페이지당 보여줄 매물 개수")
+                       ),
                        requestFields(
                                fieldWithPath("typeList[].id").description("차종 리스트 : 아이디"),
                                fieldWithPath("typeList[].name").description("차종 리스트 : 내용"),
@@ -334,15 +341,33 @@ class ProductControllerTest extends CommonTest {
                                fieldWithPath("branchList").description("판매 지점 리스트")
                        ),
                        responseFields(
-                               fieldWithPath("[].id").description("아이디"),
-                               fieldWithPath("[].title").description("제목(모델+차량명+연식)"),
-                               fieldWithPath("[].distance").description("주행 거리"),
-                               fieldWithPath("[].branch").description("판매 지점"),
-                               fieldWithPath("[].price").description("판매 가격"),
-                               fieldWithPath("[].imageUrl").description("이미지 리스트")
+                               fieldWithPath("content[].id").description("아이디"),
+                               fieldWithPath("content[].title").description("제목(모델+차량명+연식)"),
+                               fieldWithPath("content[].distance").description("주행 거리"),
+                               fieldWithPath("content[].branch").description("판매 지점"),
+                               fieldWithPath("content[].price").description("판매 가격"),
+                               fieldWithPath("content[].imageUrl").description("이미지 리스트"),
+
+                               fieldWithPath("pageable").description("페이징 정보"),
+                               fieldWithPath("last").description("마지막 페이지 여부"),
+                               fieldWithPath("totalPages").description("총 페이지 수"),
+                               fieldWithPath("totalElements").description("총 요소 수"),
+                               fieldWithPath("size").description("페이지 크기"),
+                               fieldWithPath("number").description("현재 페이지 번호"),
+                               fieldWithPath("sort.empty").description("정렬 여부 (비어 있음)"),
+                               fieldWithPath("sort.sorted").description("정렬 여부 (정렬됨)"),
+                               fieldWithPath("sort.unsorted").description("정렬 여부 (정렬되지 않음)"),
+                               fieldWithPath("numberOfElements").description("현재 페이지의 요소 수"),
+                               fieldWithPath("first").description("첫 번째 페이지 여부"),
+                               fieldWithPath("empty").description("결과가 비어 있는지 여부")
                        )))
                .andExpect(status().isOk())
-               .andExpect(jsonPath("$.[0]").exists())
+               .andExpect(jsonPath("$.content[0].id").value(productInfo.getId()))
+               .andExpect(jsonPath("$.content[0].title").value(productInfo.getTitle()))
+               .andExpect(jsonPath("$.content[0].distance").value(productInfo.getDistance()))
+               .andExpect(jsonPath("$.content[0].branch").value(productInfo.getBranch()))
+               .andExpect(jsonPath("$.content[0].price").value(productInfo.getPrice()))
+               .andExpect(jsonPath("$.content[0].imageUrl").value(productInfo.getImageUrl()))
                .andReturn();
    }
 
@@ -381,33 +406,54 @@ class ProductControllerTest extends CommonTest {
        List<ProductInfo> productInfoList = new ArrayList<>();
        productInfoList.add(productInfo);
 
+       PageImpl<ProductInfo> productInfoListPageable = new PageImpl<>(productInfoList);
+
        String keyword = "기아";
 
-       when(productService.findSearchedProduct(keyword)).thenReturn(productInfoList);
+       Pageable pageable = PageRequest.of(0,5);
+
+       when(productService.findSearchedProduct(any(), any())).thenReturn(productInfoListPageable);
 
        mockMvc.perform(get("/product/search")
                        .param("keyword", keyword)
+                       .param("page", String.valueOf(pageable.getOffset()))
+                       .param("size", String.valueOf(pageable.getPageSize()))
                        .contentType(MediaType.APPLICATION_JSON))
                .andDo(print())
                .andDo(document("product/search",
                        requestParameters(
-                               parameterWithName("keyword").description("검색 키워드")
+                               parameterWithName("keyword").description("검색 키워드"),
+                               parameterWithName("page").description("페이지 오프셋"),
+                               parameterWithName("size").description("페이지당 보여줄 매물 개수")
                        ),
                        responseFields(
-                               fieldWithPath("[].id").description("아이디"),
-                               fieldWithPath("[].title").description("제목(모델+차량명+연식)"),
-                               fieldWithPath("[].distance").description("주행 거리"),
-                               fieldWithPath("[].branch").description("판매 지점"),
-                               fieldWithPath("[].price").description("판매 가격"),
-                               fieldWithPath("[].imageUrl").description("이미지 리스트")
+                               fieldWithPath("content[].id").description("아이디"),
+                               fieldWithPath("content[].title").description("제목(모델+차량명+연식)"),
+                               fieldWithPath("content[].distance").description("주행 거리"),
+                               fieldWithPath("content[].branch").description("판매 지점"),
+                               fieldWithPath("content[].price").description("판매 가격"),
+                               fieldWithPath("content[].imageUrl").description("이미지 리스트"),
+
+                               fieldWithPath("pageable").description("페이징 정보"),
+                               fieldWithPath("last").description("마지막 페이지 여부"),
+                               fieldWithPath("totalPages").description("총 페이지 수"),
+                               fieldWithPath("totalElements").description("총 요소 수"),
+                               fieldWithPath("size").description("페이지 크기"),
+                               fieldWithPath("number").description("현재 페이지 번호"),
+                               fieldWithPath("sort.empty").description("정렬 여부 (비어 있음)"),
+                               fieldWithPath("sort.sorted").description("정렬 여부 (정렬됨)"),
+                               fieldWithPath("sort.unsorted").description("정렬 여부 (정렬되지 않음)"),
+                               fieldWithPath("numberOfElements").description("현재 페이지의 요소 수"),
+                               fieldWithPath("first").description("첫 번째 페이지 여부"),
+                               fieldWithPath("empty").description("결과가 비어 있는지 여부")
                        )))
                .andExpect(status().isOk())
-               .andExpect(jsonPath("$.[0].id").value(productInfo.getId()))
-               .andExpect(jsonPath("$.[0].title").value(productInfo.getTitle()))
-               .andExpect(jsonPath("$.[0].distance").value(productInfo.getDistance()))
-               .andExpect(jsonPath("$.[0].branch").value(productInfo.getBranch()))
-               .andExpect(jsonPath("$.[0].price").value(productInfo.getPrice()))
-               .andExpect(jsonPath("$.[0].imageUrl").value(productInfo.getImageUrl()))
+               .andExpect(jsonPath("$.content[0].id").value(productInfo.getId()))
+               .andExpect(jsonPath("$.content[0].title").value(productInfo.getTitle()))
+               .andExpect(jsonPath("$.content[0].distance").value(productInfo.getDistance()))
+               .andExpect(jsonPath("$.content[0].branch").value(productInfo.getBranch()))
+               .andExpect(jsonPath("$.content[0].price").value(productInfo.getPrice()))
+               .andExpect(jsonPath("$.content[0].imageUrl").value(productInfo.getImageUrl()))
                .andReturn();
    }
 }


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- 매물 필터링 검색 API에 페이지네이션 적용
- 매물 키워드 검색 API에 페이지네이션 적용

## 관련 이슈

- Close #273

## 세부 작업 내용

- [x] ProductController의 "/product/filter", "/product/search"에 Pageable 파라미터 추가
- [x] ProductService의 관련 선언부 매게변수에 Pageable 매개변수 추가
- [x] ProductServiceImple의 관련 QueryDsl 쿼리에 페이지네이션 조건 추가
- [x] 관련 테스트 코드 수정
