### PR TITLE
[Bug] 매물 필터링 및 키워드 검색 API에서 totalElements 불일치 해결

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/domain/admin/service/impl/ApproveSaleServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/admin/service/impl/ApproveSaleServiceImpl.java
@@ -60,7 +60,7 @@ public class ApproveSaleServiceImpl implements ApproveSaleService {
                 .limit(pageable.getPageSize())
                 .fetchResults();
 
-        return new PageImpl<>(approveSaleResponseDtoList.getResults());
+        return new PageImpl<>(approveSaleResponseDtoList.getResults(), pageable, approveSaleResponseDtoList.getTotal());
     }
 
     @Override

--- a/backend/src/main/java/com/woochacha/backend/domain/product/controller/ProductController.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/controller/ProductController.java
@@ -6,12 +6,10 @@ import com.woochacha.backend.domain.product.dto.ProductPurchaseRequestDto;
 import com.woochacha.backend.domain.product.dto.all.ProductInfo;
 import com.woochacha.backend.domain.product.dto.filter.ProductFilterInfo;
 import com.woochacha.backend.domain.product.service.ProductService;
-import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/product")
@@ -34,7 +32,7 @@ public class ProductController {
     }
 
     @PostMapping("/filter")
-    public PageImpl<ProductInfo> findFilteredProduct(@RequestBody ProductFilterInfo productFilterInfo, Pageable pageable) {
+    public Page<ProductInfo> findFilteredProduct(@RequestBody ProductFilterInfo productFilterInfo, Pageable pageable) {
         return productService.findFilteredProduct(productFilterInfo, pageable);
     }
 
@@ -45,7 +43,7 @@ public class ProductController {
     }
 
     @GetMapping("/search")
-    public PageImpl<ProductInfo> findSearchedProduct(@RequestParam(value="keyword") String keyword, Pageable pageable) {
+    public Page<ProductInfo> findSearchedProduct(@RequestParam(value="keyword") String keyword, Pageable pageable) {
         return productService.findSearchedProduct(keyword, pageable);
     }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/product/dto/ProductAllResponseDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/dto/ProductAllResponseDto.java
@@ -4,11 +4,11 @@ import com.woochacha.backend.domain.product.dto.all.ProductInfo;
 import com.woochacha.backend.domain.product.dto.filter.ProductFilterInfo;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Page;
 
 @Data
 @AllArgsConstructor
 public class ProductAllResponseDto {
-    private PageImpl<ProductInfo> productInfo; // 매물 전체 정보
+    private Page<ProductInfo> productInfo; // 매물 전체 정보
     private ProductFilterInfo productFilterInfo; // 필터링 목록 정보
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/product/service/ProductService.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/service/ProductService.java
@@ -5,14 +5,14 @@ import com.woochacha.backend.domain.product.dto.ProductDetailResponseDto;
 import com.woochacha.backend.domain.product.dto.ProductPurchaseRequestDto;
 import com.woochacha.backend.domain.product.dto.all.ProductInfo;
 import com.woochacha.backend.domain.product.dto.filter.ProductFilterInfo;
-import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ProductService {
     ProductAllResponseDto findAllProduct(Pageable pageable);
     ProductDetailResponseDto findDetailProduct(Long productId);
-    PageImpl<ProductInfo> findFilteredProduct(ProductFilterInfo productFilterInfo, Pageable pageable);
+    Page<ProductInfo> findFilteredProduct(ProductFilterInfo productFilterInfo, Pageable pageable);
     void applyPurchaseForm(ProductPurchaseRequestDto productPurchaseRequestDto);
 
-    PageImpl<ProductInfo> findSearchedProduct(String keyword, Pageable pageable);
+    Page<ProductInfo> findSearchedProduct(String keyword, Pageable pageable);
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/product/service/impl/ProductServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/service/impl/ProductServiceImpl.java
@@ -172,8 +172,8 @@ public class ProductServiceImpl implements ProductService {
         return new ProductDetailResponseDto(basicInfo, productDetailInfo, productOptionInfo, productOwnerInfo, productImageList);
     }
 
-    private PageImpl<ProductInfo> findProductDynamicInfoList(BooleanExpression expression, Pageable pageable) {
-        List<ProductInfo> productInfoList =  queryFactory
+    private Page<ProductInfo> findProductDynamicInfoList(BooleanExpression expression, Pageable pageable) {
+        QueryResults<ProductInfo> productInfoList =  queryFactory
                 .select(Projections.fields(
                         ProductInfo.class, p.id,
                         Expressions.asString(
@@ -189,9 +189,9 @@ public class ProductServiceImpl implements ProductService {
                 .orderBy(p.createdAt.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .fetch();
+                .fetchResults();
 
-        return new PageImpl<>(productInfoList);
+        return new PageImpl<>(productInfoList.getResults(), pageable, productInfoList.getTotal());
     }
 
     private ProductBasicInfo getProductBasicInfo(Long productId) {
@@ -282,7 +282,7 @@ public class ProductServiceImpl implements ProductService {
     }
 
     @Override
-    public PageImpl<ProductInfo> findFilteredProduct(ProductFilterInfo productFilterInfo, Pageable pageable) {
+    public Page<ProductInfo> findFilteredProduct(ProductFilterInfo productFilterInfo, Pageable pageable) {
         return findProductDynamicInfoList(dynamicSearch(productFilterInfo), pageable);
     }
 
@@ -373,9 +373,9 @@ public class ProductServiceImpl implements ProductService {
     }
 
     @Override
-    public PageImpl<ProductInfo> findSearchedProduct(String keyword, Pageable pageable) {
+    public Page<ProductInfo> findSearchedProduct(String keyword, Pageable pageable) {
         BooleanExpression expression = dynamicSearchWholeModelKeyword(keyword); // 모델명 검색 동적 쿼리 생성
-        PageImpl<ProductInfo> keywordSearchedByModelName = findProductDynamicInfoList(expression, pageable); // 모델명 동적 쿼리 실행
+        Page<ProductInfo> keywordSearchedByModelName = findProductDynamicInfoList(expression, pageable); // 모델명 동적 쿼리 실행
 
         // 모델명 검색 결과가 없으면 차량명 검색 동작
         if (keywordSearchedByModelName.isEmpty())

--- a/backend/src/main/java/com/woochacha/backend/domain/product/service/impl/ProductServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/product/service/impl/ProductServiceImpl.java
@@ -1,5 +1,6 @@
 package com.woochacha.backend.domain.product.service.impl;
 
+import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -34,6 +35,7 @@ import com.woochacha.backend.domain.sale.entity.QBranch;
 import com.woochacha.backend.domain.sale.entity.QSaleForm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -83,15 +85,15 @@ public class ProductServiceImpl implements ProductService {
      */
     @Override
     public ProductAllResponseDto findAllProduct(Pageable pageable) {
-        PageImpl<ProductInfo> productInfoList = findAllProductInfoList(pageable);
+        Page<ProductInfo> productInfoList = findAllProductInfoList(pageable);
 
         ProductFilterInfo productFilterInfo = findAllProductFilterList();
 
         return new ProductAllResponseDto(productInfoList, productFilterInfo);
     }
 
-    private PageImpl<ProductInfo> findProductInfoListPageable(Pageable pageable) {
-        List<ProductInfo> productInfoList = queryFactory
+    private Page<ProductInfo> findProductInfoListPageable(Pageable pageable) {
+        QueryResults<ProductInfo> productInfoList = queryFactory
                 .select(Projections.fields(
                         ProductInfo.class, p.id,
                         Expressions.asString(
@@ -107,13 +109,13 @@ public class ProductServiceImpl implements ProductService {
                 .orderBy(p.createdAt.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .fetch();
+                .fetchResults();
 
-        return new PageImpl<>(productInfoList);
+        return new PageImpl<>(productInfoList.getResults(), pageable, productInfoList.getTotal());
     }
 
     // 전체 매물 조회
-    private PageImpl<ProductInfo> findAllProductInfoList(Pageable pageable) {
+    private Page<ProductInfo> findAllProductInfoList(Pageable pageable) {
         return findProductInfoListPageable(pageable);
     }
 

--- a/backend/src/test/java/com/woochacha/backend/domain/admin/controller/ApproveSaleControllerTest.java
+++ b/backend/src/test/java/com/woochacha/backend/domain/admin/controller/ApproveSaleControllerTest.java
@@ -23,8 +23,13 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -73,30 +78,40 @@ class ApproveSaleControllerTest extends CommonTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
-//                .andDo(document("admin/sales",
-//                        requestParameters(
-//                                parameterWithName("pageable").description("페이지네이션")
-//                        ),
-//                        responseFields(
-//                                fieldWithPath("content[].id").description("saleform Id"),
-//                                fieldWithPath("content[].name").description("판매 요청 회원 이름"),
-//                                fieldWithPath("content[].carNum").description("판매 차량 번호"),
-//                                fieldWithPath("content[].status").description("saleform의 현재 상태"),
-//
-//                                fieldWithPath("pageable").description("페이징 정보"),
-//                                fieldWithPath("last").description("마지막 페이지 여부"),
-//                                fieldWithPath("totalPages").description("총 페이지 수"),
-//                                fieldWithPath("totalElements").description("총 요소 수"),
-//                                fieldWithPath("size").description("페이지 크기"),
-//                                fieldWithPath("number").description("현재 페이지 번호"),
-//                                fieldWithPath("sort.empty").description("정렬 여부 (비어 있음)"),
-//                                fieldWithPath("sort.sorted").description("정렬 여부 (정렬됨)"),
-//                                fieldWithPath("sort.unsorted").description("정렬 여부 (정렬되지 않음)"),
-//
-//                                fieldWithPath("numberOfElements").description("현재 페이지의 요소 수"),
-//                                fieldWithPath("first").description("첫 번째 페이지 여부"),
-//                                fieldWithPath("empty").description("결과가 비어 있는지 여부")
-//                        )))
+                .andDo(document("admin/sales",
+                        requestParameters(
+                                parameterWithName("pageable").description("페이지네이션")
+                        ),
+                        responseFields(
+                                fieldWithPath("content[].id").description("saleform Id"),
+                                fieldWithPath("content[].name").description("판매 요청 회원 이름"),
+                                fieldWithPath("content[].carNum").description("판매 차량 번호"),
+                                fieldWithPath("content[].status").description("saleform의 현재 상태"),
+
+                                fieldWithPath("pageable.sort.empty").description("정렬 여부 (비어 있음)"),
+                                fieldWithPath("pageable.sort.sorted").description("정렬 여부 (정렬됨)"),
+                                fieldWithPath("pageable.sort.unsorted").description("정렬 여부 (정렬되지 않음)"),
+
+                                fieldWithPath("pageable.offset").description("페이지 오프셋 값"),
+                                fieldWithPath("pageable.pageSize").description("페이지 크기"),
+                                fieldWithPath("pageable.pageNumber").description("현재 페이지 번호"),
+                                fieldWithPath("pageable.paged").description("페이지 여부 (페이징된 경우 true, 그렇지 않으면 false)"),
+                                fieldWithPath("pageable.unpaged").description("페이징되지 않은 경우 true, 그렇지 않으면 false"),
+
+                                fieldWithPath("pageable").description("페이징 정보"),
+                                fieldWithPath("last").description("마지막 페이지 여부"),
+                                fieldWithPath("totalPages").description("총 페이지 수"),
+                                fieldWithPath("totalElements").description("총 요소 수"),
+                                fieldWithPath("size").description("페이지 크기"),
+                                fieldWithPath("number").description("현재 페이지 번호"),
+                                fieldWithPath("sort.empty").description("정렬 여부 (비어 있음)"),
+                                fieldWithPath("sort.sorted").description("정렬 여부 (정렬됨)"),
+                                fieldWithPath("sort.unsorted").description("정렬 여부 (정렬되지 않음)"),
+
+                                fieldWithPath("numberOfElements").description("현재 페이지의 요소 수"),
+                                fieldWithPath("first").description("첫 번째 페이지 여부"),
+                                fieldWithPath("empty").description("결과가 비어 있는지 여부")
+                        )))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].id").value(approveSaleResponseDto.getId()))
                 .andExpect(jsonPath("$.content[0].name").value(approveSaleResponseDto.getName()))

--- a/backend/src/test/java/com/woochacha/backend/domain/admin/controller/ApproveSaleControllerTest.java
+++ b/backend/src/test/java/com/woochacha/backend/domain/admin/controller/ApproveSaleControllerTest.java
@@ -23,13 +23,8 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -69,37 +64,39 @@ class ApproveSaleControllerTest extends CommonTest {
 
         Pageable pageable = PageRequest.of(0,5);
 
-        when(approveSaleService.getApproveSaleForm(any())).thenReturn(new PageImpl<>(approveSaleResponseDtoList.getResults()));
+        when(approveSaleService.getApproveSaleForm(any())).thenReturn(
+                new PageImpl<>(
+                        approveSaleResponseDtoList.getResults(), pageable, approveSaleResponseDtoList.getTotal()));
 
         mockMvc.perform(get("/admin/sales")
                         .param("pageable", String.valueOf(pageable))
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andDo(document("admin/sales",
-                        requestParameters(
-                                parameterWithName("pageable").description("페이지네이션")
-                        ),
-                        responseFields(
-                                fieldWithPath("content[].id").description("saleform Id"),
-                                fieldWithPath("content[].name").description("판매 요청 회원 이름"),
-                                fieldWithPath("content[].carNum").description("판매 차량 번호"),
-                                fieldWithPath("content[].status").description("saleform의 현재 상태"),
-
-                                fieldWithPath("pageable").description("페이징 정보"),
-                                fieldWithPath("last").description("마지막 페이지 여부"),
-                                fieldWithPath("totalPages").description("총 페이지 수"),
-                                fieldWithPath("totalElements").description("총 요소 수"),
-                                fieldWithPath("size").description("페이지 크기"),
-                                fieldWithPath("number").description("현재 페이지 번호"),
-                                fieldWithPath("sort.empty").description("정렬 여부 (비어 있음)"),
-                                fieldWithPath("sort.sorted").description("정렬 여부 (정렬됨)"),
-                                fieldWithPath("sort.unsorted").description("정렬 여부 (정렬되지 않음)"),
-
-                                fieldWithPath("numberOfElements").description("현재 페이지의 요소 수"),
-                                fieldWithPath("first").description("첫 번째 페이지 여부"),
-                                fieldWithPath("empty").description("결과가 비어 있는지 여부")
-                        )))
+//                .andDo(document("admin/sales",
+//                        requestParameters(
+//                                parameterWithName("pageable").description("페이지네이션")
+//                        ),
+//                        responseFields(
+//                                fieldWithPath("content[].id").description("saleform Id"),
+//                                fieldWithPath("content[].name").description("판매 요청 회원 이름"),
+//                                fieldWithPath("content[].carNum").description("판매 차량 번호"),
+//                                fieldWithPath("content[].status").description("saleform의 현재 상태"),
+//
+//                                fieldWithPath("pageable").description("페이징 정보"),
+//                                fieldWithPath("last").description("마지막 페이지 여부"),
+//                                fieldWithPath("totalPages").description("총 페이지 수"),
+//                                fieldWithPath("totalElements").description("총 요소 수"),
+//                                fieldWithPath("size").description("페이지 크기"),
+//                                fieldWithPath("number").description("현재 페이지 번호"),
+//                                fieldWithPath("sort.empty").description("정렬 여부 (비어 있음)"),
+//                                fieldWithPath("sort.sorted").description("정렬 여부 (정렬됨)"),
+//                                fieldWithPath("sort.unsorted").description("정렬 여부 (정렬되지 않음)"),
+//
+//                                fieldWithPath("numberOfElements").description("현재 페이지의 요소 수"),
+//                                fieldWithPath("first").description("첫 번째 페이지 여부"),
+//                                fieldWithPath("empty").description("결과가 비어 있는지 여부")
+//                        )))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].id").value(approveSaleResponseDto.getId()))
                 .andExpect(jsonPath("$.content[0].name").value(approveSaleResponseDto.getName()))

--- a/backend/src/test/java/com/woochacha/backend/domain/product/controller/ProductControllerTest.java
+++ b/backend/src/test/java/com/woochacha/backend/domain/product/controller/ProductControllerTest.java
@@ -125,7 +125,7 @@ class ProductControllerTest extends CommonTest {
        when(productService.findAllProduct(any())).thenReturn(productAllResponseDto);
 
        mockMvc.perform(get("/product")
-               .param("page", String.valueOf(pageable.getPageNumber()))
+               .param("page", String.valueOf(pageable.getOffset()))
                .param("size", String.valueOf(pageable.getPageSize())))
                .andExpect(status().isOk())
                .andDo(document("product/get-all",

--- a/backend/src/test/java/com/woochacha/backend/domain/product/controller/ProductControllerTest.java
+++ b/backend/src/test/java/com/woochacha/backend/domain/product/controller/ProductControllerTest.java
@@ -78,17 +78,6 @@ class ProductControllerTest extends CommonTest {
 
        List<ProductInfo> productInfoList = new ArrayList<>();
        productInfoList.add(productInfo);
-       productInfoList.add(productInfo);
-       productInfoList.add(productInfo);
-       productInfoList.add(productInfo);
-       productInfoList.add(productInfo);
-       productInfoList.add(productInfo);
-       productInfoList.add(productInfo);
-       productInfoList.add(productInfo);
-       productInfoList.add(productInfo);
-       productInfoList.add(productInfo);
-       productInfoList.add(productInfo);
-       productInfoList.add(productInfo);
 
        QueryResults<ProductInfo> result = new QueryResults<>(productInfoList, 5L, 0L, 10L);
 
@@ -340,11 +329,13 @@ class ProductControllerTest extends CommonTest {
        List<ProductInfo> productInfoList = new ArrayList<>();
        productInfoList.add(productInfo);
 
-       PageImpl<ProductInfo> productInfoListPageable = new PageImpl<>(productInfoList);
+       QueryResults<ProductInfo> result = new QueryResults<>(productInfoList, 0L, 0L, productInfoList.size());
 
        Pageable pageable = PageRequest.of(0,5);
 
-       when(productService.findFilteredProduct(any(ProductFilterInfo.class), any())).thenReturn(productInfoListPageable);
+       Page<ProductInfo> reulstPage = new PageImpl<>(result.getResults(), pageable, result.getTotal());
+
+       when(productService.findFilteredProduct(any(ProductFilterInfo.class), any())).thenReturn(reulstPage);
 
        mockMvc.perform(post("/product/filter")
                        .param("page", String.valueOf(pageable.getOffset()))
@@ -374,6 +365,16 @@ class ProductControllerTest extends CommonTest {
                                fieldWithPath("content[].branch").description("판매 지점"),
                                fieldWithPath("content[].price").description("판매 가격"),
                                fieldWithPath("content[].imageUrl").description("이미지 리스트"),
+
+                               fieldWithPath("pageable.sort.empty").description("정렬 여부 (비어 있음)"),
+                               fieldWithPath("pageable.sort.sorted").description("정렬 여부 (정렬됨)"),
+                               fieldWithPath("pageable.sort.unsorted").description("정렬 여부 (정렬되지 않음)"),
+
+                               fieldWithPath("pageable.offset").description("페이지 오프셋 값"),
+                               fieldWithPath("pageable.pageSize").description("페이지 크기"),
+                               fieldWithPath("pageable.pageNumber").description("현재 페이지 번호"),
+                               fieldWithPath("pageable.paged").description("페이지 여부 (페이징된 경우 true, 그렇지 않으면 false)"),
+                               fieldWithPath("pageable.unpaged").description("페이징되지 않은 경우 true, 그렇지 않으면 false"),
 
                                fieldWithPath("pageable").description("페이징 정보"),
                                fieldWithPath("last").description("마지막 페이지 여부"),
@@ -433,13 +434,13 @@ class ProductControllerTest extends CommonTest {
        List<ProductInfo> productInfoList = new ArrayList<>();
        productInfoList.add(productInfo);
 
-       PageImpl<ProductInfo> productInfoListPageable = new PageImpl<>(productInfoList);
+       QueryResults<ProductInfo> result = new QueryResults<>(productInfoList, 0L, 0L, productInfoList.size());
+       Pageable pageable = PageRequest.of(0,5);
+       Page<ProductInfo> reulstPage = new PageImpl<>(result.getResults(), pageable, result.getTotal());
 
        String keyword = "기아";
 
-       Pageable pageable = PageRequest.of(0,5);
-
-       when(productService.findSearchedProduct(any(), any())).thenReturn(productInfoListPageable);
+       when(productService.findSearchedProduct(any(), any())).thenReturn(reulstPage);
 
        mockMvc.perform(get("/product/search")
                        .param("keyword", keyword)
@@ -460,6 +461,16 @@ class ProductControllerTest extends CommonTest {
                                fieldWithPath("content[].branch").description("판매 지점"),
                                fieldWithPath("content[].price").description("판매 가격"),
                                fieldWithPath("content[].imageUrl").description("이미지 리스트"),
+
+                               fieldWithPath("pageable.sort.empty").description("정렬 여부 (비어 있음)"),
+                               fieldWithPath("pageable.sort.sorted").description("정렬 여부 (정렬됨)"),
+                               fieldWithPath("pageable.sort.unsorted").description("정렬 여부 (정렬되지 않음)"),
+
+                               fieldWithPath("pageable.offset").description("페이지 오프셋 값"),
+                               fieldWithPath("pageable.pageSize").description("페이지 크기"),
+                               fieldWithPath("pageable.pageNumber").description("현재 페이지 번호"),
+                               fieldWithPath("pageable.paged").description("페이지 여부 (페이징된 경우 true, 그렇지 않으면 false)"),
+                               fieldWithPath("pageable.unpaged").description("페이징되지 않은 경우 true, 그렇지 않으면 false"),
 
                                fieldWithPath("pageable").description("페이징 정보"),
                                fieldWithPath("last").description("마지막 페이지 여부"),

--- a/backend/src/test/java/com/woochacha/backend/domain/product/controller/ProductControllerTest.java
+++ b/backend/src/test/java/com/woochacha/backend/domain/product/controller/ProductControllerTest.java
@@ -1,6 +1,7 @@
 package com.woochacha.backend.domain.product.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.querydsl.core.QueryResults;
 import com.woochacha.backend.domain.car.detail.dto.CarNameDto;
 import com.woochacha.backend.domain.car.type.dto.*;
 import com.woochacha.backend.domain.common.CommonTest;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -37,7 +39,6 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -77,7 +78,24 @@ class ProductControllerTest extends CommonTest {
 
        List<ProductInfo> productInfoList = new ArrayList<>();
        productInfoList.add(productInfo);
-       PageImpl<ProductInfo> productInfoListPageable = new PageImpl<>(productInfoList);
+       productInfoList.add(productInfo);
+       productInfoList.add(productInfo);
+       productInfoList.add(productInfo);
+       productInfoList.add(productInfo);
+       productInfoList.add(productInfo);
+       productInfoList.add(productInfo);
+       productInfoList.add(productInfo);
+       productInfoList.add(productInfo);
+       productInfoList.add(productInfo);
+       productInfoList.add(productInfo);
+       productInfoList.add(productInfo);
+
+       QueryResults<ProductInfo> result = new QueryResults<>(productInfoList, 5L, 0L, 10L);
+
+       Pageable pageable = PageRequest.of(0,5);
+
+       Page<ProductInfo> reulstPage = new PageImpl<>(result.getResults(), pageable, result.getTotal());
+
 
        TypeDto typeDto  = new TypeDto(1, "경차");
        ModelDto modelDto = new ModelDto(1, "현대");
@@ -113,14 +131,12 @@ class ProductControllerTest extends CommonTest {
                .branchList(branchDtoList)
                .build();
 
-       ProductAllResponseDto productAllResponseDto = new ProductAllResponseDto(productInfoListPageable, productFilterInfo);
-
-       Pageable pageable = PageRequest.of(0,5);
+       ProductAllResponseDto productAllResponseDto = new ProductAllResponseDto(reulstPage, productFilterInfo);
 
        when(productService.findAllProduct(any())).thenReturn(productAllResponseDto);
 
        mockMvc.perform(get("/product")
-               .param("page", String.valueOf(pageable.getOffset()))
+               .param("page", String.valueOf(pageable.getPageNumber()))
                .param("size", String.valueOf(pageable.getPageSize())))
                .andExpect(status().isOk())
                .andDo(document("product/get-all",
@@ -136,6 +152,16 @@ class ProductControllerTest extends CommonTest {
                                fieldWithPath("productInfo.content[].branch").description("판매 지점"),
                                fieldWithPath("productInfo.content[].price").description("판매 가격"),
                                fieldWithPath("productInfo.content[].imageUrl").description("이미지 리스트"),
+
+                               fieldWithPath("productInfo.pageable.sort.empty").description("정렬 여부 (비어 있음)"),
+                               fieldWithPath("productInfo.pageable.sort.sorted").description("정렬 여부 (정렬됨)"),
+                               fieldWithPath("productInfo.pageable.sort.unsorted").description("정렬 여부 (정렬되지 않음)"),
+
+                               fieldWithPath("productInfo.pageable.offset").description("페이지 오프셋 값"),
+                               fieldWithPath("productInfo.pageable.pageSize").description("페이지 크기"),
+                               fieldWithPath("productInfo.pageable.pageNumber").description("현재 페이지 번호"),
+                               fieldWithPath("productInfo.pageable.paged").description("페이지 여부 (페이징된 경우 true, 그렇지 않으면 false)"),
+                               fieldWithPath("productInfo.pageable.unpaged").description("페이징되지 않은 경우 true, 그렇지 않으면 false"),
 
                                fieldWithPath("productInfo.pageable").description("페이징 정보"),
                                fieldWithPath("productInfo.last").description("마지막 페이지 여부"),

--- a/backend/src/test/java/com/woochacha/backend/domain/product/controller/ProductControllerTest.java
+++ b/backend/src/test/java/com/woochacha/backend/domain/product/controller/ProductControllerTest.java
@@ -85,7 +85,6 @@ class ProductControllerTest extends CommonTest {
 
        Page<ProductInfo> reulstPage = new PageImpl<>(result.getResults(), pageable, result.getTotal());
 
-
        TypeDto typeDto  = new TypeDto(1, "경차");
        ModelDto modelDto = new ModelDto(1, "현대");
        CarNameDto carNameDto = new CarNameDto(1L, "아반떼 AD");


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 해결 버그

- 매물 필터링 및 키워드 검색 API에서 totalElements 불일치

## 관련 이슈

- Close #276

## 세부 작업 내용

- [ ] Page 객체 생성 시, productInfoList만 매개변수로 전달하던 것에서 productInfoList.getResults(), pageable, productInfoList.getTotal() 정보를 모두 전달하는 것으로 수정
- [ ] 테스트 코드 수정
