### PR TITLE
[Feature] 매물 키워드 검색 로직 변경&REST Docs security 권한 설정

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/security/configs/SecurityConfig.java
+++ b/backend/src/main/java/com/woochacha/backend/security/configs/SecurityConfig.java
@@ -76,6 +76,7 @@ public class SecurityConfig {
 
                 .and() // TODO: 권한이 필요한 작업 전에 jwt principle과 email 비교해서 일치한 경우에만 진행되도록 리팩토링
                 .authorizeRequests()
+                .antMatchers("/docs/Woochacha-user.html", "/docs/Woocahcha-admin.html").permitAll()
                 .antMatchers("/", "/users/register", "/users/login", "/product").permitAll()
                 .antMatchers("/users/**", "/product/sale", "/product/purchase", "/mypage/**").hasRole("USER")
                 .antMatchers("/product/**").permitAll()


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- 매물 키워드 검색 로직 변경
- REST Docs security 권한 설정

## 관련 이슈

- Close #291

## 세부 작업 내용

- [x] 아래와 같이 검색 기준 변경
    - 기존 : 매물 모델 전체 일치 수행. 없으면 이름 음절 일치 수행
    - 수정 후 : 
        1. 키워드와 전체 모델명이 일치하는지 확인
             1) 일치하는 매물이 있으면 해당 데이터 리턴
             2) 없으면 다음 로직 수행
        2. 키워드와  전체 차명이 일치하는지 확인
             1) 일치하는 매물이 있으면 해당 데이터 리턴
             2) 없으면 다음 로직 수행
        3. 모델과 차명 관계 없이 키워드의 공백을 기준으로 각 단어를 포함하는 매물 조회
 - [x] 외부에서 rest docs html 파일 접근을 위한 1차 설정으로 Security 설정에서 전체 접근 권한 경로로 rest docs 파일 설정

## 참고 사항

- 아래는 수정 후 로직의 수행 결과입니다.
- 혹시 다른 예외나 오류가 있다면 바로 말씀해주세요. 수정하겠습니다!

![4](https://github.com/woorifisa-projects/woochacha/assets/93786956/bb3e7a39-bf63-4cc8-a914-a9c65b507753)
![3](https://github.com/woorifisa-projects/woochacha/assets/93786956/e754a453-fd76-45a1-93e1-600369a0b35a)
![2](https://github.com/woorifisa-projects/woochacha/assets/93786956/e1d26e5e-74ed-487d-98c8-5d87438469ff)
![1](https://github.com/woorifisa-projects/woochacha/assets/93786956/00c73f9e-b43a-4348-8ee9-5ce8e6b8781e)
