### PR TITLE
[Feature] member email, phone 암호화, 복호화 구현

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/common/DataMasking.java
+++ b/backend/src/main/java/com/woochacha/backend/common/DataMasking.java
@@ -1,0 +1,21 @@
+package com.woochacha.backend.common;
+
+import org.springframework.security.crypto.encrypt.TextEncryptor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataMasking {
+
+    private final TextEncryptor textEncryptor;
+
+    public DataMasking(TextEncryptor textEncryptor) {
+        this.textEncryptor = textEncryptor;
+    }
+    public String encoding(String plainText) {
+        return textEncryptor.encrypt(plainText);
+    }
+
+    public String decoding(String encryptText) {
+        return textEncryptor.decrypt(encryptText);
+    }
+}

--- a/backend/src/main/java/com/woochacha/backend/domain/member/service/impl/SignServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/service/impl/SignServiceImpl.java
@@ -2,6 +2,7 @@ package com.woochacha.backend.domain.member.service.impl;
 
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.woochacha.backend.common.DataMasking;
 import com.woochacha.backend.common.ModelMapping;
 import com.woochacha.backend.domain.jwt.JwtAuthenticationFilter;
 import com.woochacha.backend.domain.jwt.JwtTokenProvider;
@@ -60,14 +61,17 @@ public class SignServiceImpl implements SignService {
 
     private final LogServiceImpl logService;
 
+    private final DataMasking dataMasking;
+
     public SignServiceImpl(JPAQueryFactory queryFactory, MemberRepository memberRepository, JwtTokenProvider jwtTokenProvider,
-                           PasswordEncoder passwordEncoder, AuthenticationManagerBuilder authenticationManagerBuilder, LogServiceImpl logService) {
+                           PasswordEncoder passwordEncoder, AuthenticationManagerBuilder authenticationManagerBuilder, LogServiceImpl logService, DataMasking dataMasking) {
         this.queryFactory = queryFactory;
         this.memberRepository = memberRepository;
         this.jwtTokenProvider = jwtTokenProvider;
         this.passwordEncoder = passwordEncoder;
         this.authenticationManagerBuilder = authenticationManagerBuilder;
         this.logService = logService;
+        this.dataMasking = dataMasking;
     }
 
     /*
@@ -221,10 +225,20 @@ public class SignServiceImpl implements SignService {
         return SignException.exception(SignResultCode.SUCCESS);
     }
 
+
+
     private Member save(SignUpRequestDto signUpRequestDto) {
         signUpRequestDto.setPassword(passwordEncoder.encode(signUpRequestDto.getPassword()));
+
+        // 이메일 암호화
+        signUpRequestDto.setEmail(dataMasking.encoding(signUpRequestDto.getEmail()));
+
+        // 비밀번호 암호화
+        signUpRequestDto.setPhone(dataMasking.encoding(signUpRequestDto.getPhone()));
+
         Member savedMember = modelMapper.map(signUpRequestDto, Member.class);
         savedMember.getRoles().add("USER");
+
         memberRepository.save(savedMember);
         return savedMember;
     }

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/ProfileDto.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/dto/ProfileDto.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 
 @Getter
 @Builder
+@Setter
 public class ProfileDto {
 
     private String profileImage; // 프로필 사진

--- a/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/mypage/service/impl/MypageServiceImpl.java
@@ -1,9 +1,9 @@
 package com.woochacha.backend.domain.mypage.service.impl;
 
+import com.woochacha.backend.common.DataMasking;
 import com.woochacha.backend.common.ModelMapping;
 import com.woochacha.backend.domain.AmazonS3.dto.AmazonS3RequestDto;
 import com.woochacha.backend.domain.AmazonS3.service.AmazonS3Service;
-import com.woochacha.backend.domain.AmazonS3.service.AmazonS3ServiceImpl;
 import com.woochacha.backend.domain.log.service.LogService;
 import com.woochacha.backend.domain.member.entity.Member;
 import com.woochacha.backend.domain.member.repository.MemberRepository;
@@ -35,6 +35,8 @@ public class MypageServiceImpl implements MypageService {
     private final Logger logger = LoggerFactory.getLogger(MypageServiceImpl.class);
 
     private final LogService logService;
+
+    private final DataMasking dataMasking;
 
     // JPQL로 조회한 결과 ProductResponseDto로 변환
     private ProductResponseDto arrayToProductResponseDto(Object[] array) {
@@ -120,7 +122,10 @@ public class MypageServiceImpl implements MypageService {
     @Override
     public ProfileDto getProfileByMemberId(Long memberId) {
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new RuntimeException("Member not found"));
-        return modelMapper.map(member, ProfileDto.class);
+        ProfileDto profileDto = modelMapper.map(member, ProfileDto.class);
+        profileDto.setEmail(dataMasking.decoding(profileDto.getEmail()));
+        profileDto.setPhone(dataMasking.decoding(profileDto.getPhone()));
+        return profileDto;
     }
 
     // 판매 신청 폼 조회
@@ -200,4 +205,3 @@ public class MypageServiceImpl implements MypageService {
         return newProfileIamge;
     }
 }
-

--- a/backend/src/main/java/com/woochacha/backend/security/configs/SecurityConfig.java
+++ b/backend/src/main/java/com/woochacha/backend/security/configs/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.woochacha.backend.domain.jwt.JwtAccessDeniedHandler;
 import com.woochacha.backend.domain.jwt.JwtAuthenticationEntryPoint;
 import com.woochacha.backend.domain.jwt.JwtAuthenticationFilter;
 import com.woochacha.backend.domain.jwt.JwtTokenProvider;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.security.ConditionalOnDefaultWebSecurity;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
@@ -14,9 +15,12 @@ import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.encrypt.Encryptors;
+import org.springframework.security.crypto.encrypt.TextEncryptor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.util.DigestUtils;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -34,6 +38,12 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
+    @Value("${decode.password.key}")
+    private String passwordKey;
+
+    @Value("${decode.salt.key}")
+    private String saltKey;
+
     public SecurityConfig(
             JwtTokenProvider jwtTokenProvider,
             JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint,
@@ -49,13 +59,21 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder();
     }
 
+    @Bean
+    public TextEncryptor textEncryptor() {
+        String password = DigestUtils.md5DigestAsHex(passwordKey.getBytes()); // 비밀 키
+        String salt = DigestUtils.md5DigestAsHex(saltKey.getBytes());
+
+        return Encryptors.text(password, salt);
+    }
+
     // img, js, css 파일 등 보안 필터를 적용할 필요가 없는 리소스를 설정
 //    @Override
     public void configure(WebSecurity web) throws Exception {
         web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
     }
 
-//    @Override
+    //    @Override
 //    protected void configure(final HttpSecurity http) throws Exception {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -76,7 +94,8 @@ public class SecurityConfig {
 
                 .and() // TODO: 권한이 필요한 작업 전에 jwt principle과 email 비교해서 일치한 경우에만 진행되도록 리팩토링
                 .authorizeRequests()
-                .antMatchers("/docs/Woochacha-user.html", "/docs/Woocahcha-admin.html").permitAll()
+                .antMatchers("/docs/**").permitAll()
+                .antMatchers("/docs/Woochacha-admin.html", "/docs/Woochacha-admin.html").permitAll()
                 .antMatchers("/", "/users/register", "/users/login", "/product").permitAll()
                 .antMatchers("/users/**", "/product/sale", "/product/purchase", "/mypage/**").hasRole("USER")
                 .antMatchers("/product/**").permitAll()


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- 문제 해결 해커톤 3번 문제와 관련하여 Member 테이블의 email, phone을 암호화/복호화 하는 기능 구현

## 관련 이슈

- Close #305

## 세부 작업 내용

- [x] DataMasking 클래스 구현 : 암호화 할 때는 dataMasking.encoding(planText), 복호화 할 때는 dataMasking.decoding(encodingText) 사용
- [x] 회원가입 API에 암호화하여 email, phone 데이터 저장
- [x] 마이페이지 조회 API에 복호화하여 email, phone 데이터 조회

## 참고 사항

- 회원가입 중복 여부에 대해서는 다음 pr에 적용 예정입니다!
