### PR TITLE
[Feature] 중복 회원가입 방지 로직에 암호화 기능 구현&비암호화의 복호화 방지 기능 구현

### DIFF
--- a/backend/src/main/java/com/woochacha/backend/common/DataMasking.java
+++ b/backend/src/main/java/com/woochacha/backend/common/DataMasking.java
@@ -16,6 +16,8 @@ public class DataMasking {
     }
 
     public String decoding(String encryptText) {
+        if(encryptText.contains("010") || encryptText.contains(".com"))
+            return encryptText;
         return textEncryptor.decrypt(encryptText);
     }
 }

--- a/backend/src/main/java/com/woochacha/backend/domain/member/service/impl/SignServiceImpl.java
+++ b/backend/src/main/java/com/woochacha/backend/domain/member/service/impl/SignServiceImpl.java
@@ -178,9 +178,9 @@ public class SignServiceImpl implements SignService {
             String decodingPhone = encoded.get(m.phone);
 
             // 이미 암호화 되지 않은 상태로 저장되어 있는 데이터들은 복호화 진행 안함
-            if(!decodingPhone.contains("010")) {
+//            if(!decodingPhone.contains("010")) {
                 decodingPhone = dataMasking.decoding(encoded.get(m.phone));
-            }
+//            }
             if(decodingPhone.equals(signUpRequestDto.getPhone())) phoneDuplicateList.add(encoded);
         }
 
@@ -212,9 +212,9 @@ public class SignServiceImpl implements SignService {
             String decodingEmail = encoded.get(m.email);
 
             // 이미 암호화 되지 않은 상태로 저장되어 있는 데이터들은 복호화 진행 안함
-            if(!decodingEmail.contains(".com")) {
+//            if(!decodingEmail.contains(".com")) {
                 decodingEmail = dataMasking.decoding(encoded.get(m.email));
-            }
+//            }
             if(decodingEmail.equals(signUpRequestDto.getEmail())) emailDuplicateList.add(encoded);
         }
 

--- a/backend/src/main/java/com/woochacha/backend/security/configs/SecurityConfig.java
+++ b/backend/src/main/java/com/woochacha/backend/security/configs/SecurityConfig.java
@@ -94,11 +94,12 @@ public class SecurityConfig {
 
                 .and() // TODO: 권한이 필요한 작업 전에 jwt principle과 email 비교해서 일치한 경우에만 진행되도록 리팩토링
                 .authorizeRequests()
-                .antMatchers("/docs/Woochacha-user.html", "/docs/Woocahcha-admin.html").permitAll()
-                .antMatchers("/", "/users/register", "/users/login", "/product", "/users/auth").permitAll()
-                .antMatchers("/users/**", "/product/sale", "/product/purchase", "/mypage/**").hasRole("USER")
-                .antMatchers("/product/**").permitAll()
-                .antMatchers("/admin/**").hasRole("ADMIN")
+                .antMatchers("/**").permitAll()
+//                .antMatchers("/docs/Woochacha-user.html", "/docs/Woocahcha-admin.html").permitAll()
+//                .antMatchers("/", "/users/register", "/users/login", "/product", "/users/auth").permitAll()
+//                .antMatchers("/users/**", "/product/sale", "/product/purchase", "/mypage/**").hasRole("USER")
+//                .antMatchers("/product/**").permitAll()
+//                .antMatchers("/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated();
         return http.build();
     }

--- a/backend/src/main/java/com/woochacha/backend/security/configs/SecurityConfig.java
+++ b/backend/src/main/java/com/woochacha/backend/security/configs/SecurityConfig.java
@@ -94,12 +94,11 @@ public class SecurityConfig {
 
                 .and() // TODO: 권한이 필요한 작업 전에 jwt principle과 email 비교해서 일치한 경우에만 진행되도록 리팩토링
                 .authorizeRequests()
-                .antMatchers("/**").permitAll()
-//                .antMatchers("/docs/Woochacha-user.html", "/docs/Woocahcha-admin.html").permitAll()
-//                .antMatchers("/", "/users/register", "/users/login", "/product", "/users/auth").permitAll()
-//                .antMatchers("/users/**", "/product/sale", "/product/purchase", "/mypage/**").hasRole("USER")
-//                .antMatchers("/product/**").permitAll()
-//                .antMatchers("/admin/**").hasRole("ADMIN")
+                .antMatchers("/docs/Woochacha-user.html", "/docs/Woocahcha-admin.html").permitAll()
+                .antMatchers("/", "/users/register", "/users/login", "/product", "/users/auth").permitAll()
+                .antMatchers("/users/**", "/product/sale", "/product/purchase", "/mypage/**").hasRole("USER")
+                .antMatchers("/product/**").permitAll()
+                .antMatchers("/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated();
         return http.build();
     }


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능을 구현

-->

## 구현 기능

- 중복 회원가입 방지 로직에서 암호화/복호화 기능 구현
- 암호화되지 않은 이메일 또는 핸드폰 번호를 복호화하지 않도록 방지하는 기능 구현

## 관련 이슈

- #305

## 세부 작업 내용

- [x] 암호화되어있는 데이터의 경우 복호화하여 사용자로부터 입력 받은 데이터와 비교하는 로직 구현
- [x] signUp 메서드 모듈화
- [x] 복호화하는 경우 기존에 DB에 저장되어 있는 "010"으로 시작하는 핸드폰 번호 및 ".com"으로 끝나는 이메일의 경우에는 복호화가 진행되지 않도록 DataMasking.class의 decoding 메서드에 조건문 추가

## 참고 사항

- 이제 회원가입 이후로부터는 실제 이메일과 핸드폰번호를 복호화 하는 작업이 필요하기 때문에 상당히 귀찮아지므로 잘 기억해주세요!
